### PR TITLE
Add lot weighing records with weight tracking and plot assignment

### DIFF
--- a/prisma/neon-lot-weighings.sql
+++ b/prisma/neon-lot-weighings.sql
@@ -1,0 +1,58 @@
+-- ============================================================================
+-- Migración incremental: manejo de ganado a nivel de lote.
+-- Pega TODO este archivo en: Neon Dashboard -> SQL Editor -> Run
+-- (o aplica el esquema con `npm run db:push`).
+--
+-- Agrega:
+--   - lots.plot_id            -> ubicación del lote en un potrero (plots)
+--   - tabla "lot_weighings"   -> registros de pesado del lote
+--       (fecha, peso promedio en kg, número de animales y notas)
+-- Es idempotente: se puede correr varias veces sin error.
+-- ============================================================================
+
+-- Ubicación del lote: potrero asignado.
+ALTER TABLE "lots" ADD COLUMN IF NOT EXISTS "plot_id" INTEGER;
+
+CREATE INDEX IF NOT EXISTS "lots_plot_id_idx" ON "lots"("plot_id");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'lots_plot_id_fkey'
+  ) THEN
+    ALTER TABLE "lots"
+      ADD CONSTRAINT "lots_plot_id_fkey"
+      FOREIGN KEY ("plot_id") REFERENCES "plots"("id")
+      ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- Registros de pesado del lote. El peso promedio se almacena en kg (canónico).
+CREATE TABLE IF NOT EXISTS "lot_weighings" (
+    "id" SERIAL NOT NULL,
+    "lot_id" INTEGER,
+    "date" DATE,
+    "average_weight" DOUBLE PRECISION,
+    "animal_count" INTEGER,
+    "note" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "lot_weighings_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "lot_weighings_lot_id_idx" ON "lot_weighings"("lot_id");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'lot_weighings_lot_id_fkey'
+  ) THEN
+    ALTER TABLE "lot_weighings"
+      ADD CONSTRAINT "lot_weighings_lot_id_fkey"
+      FOREIGN KEY ("lot_id") REFERENCES "lots"("id")
+      ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/prisma/neon-setup.sql
+++ b/prisma/neon-setup.sql
@@ -39,10 +39,25 @@ CREATE TABLE "lots" (
     "number" TEXT,
     "name" TEXT,
     "description" TEXT,
+    "plot_id" INTEGER,
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT "lots_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "lot_weighings" (
+    "id" SERIAL NOT NULL,
+    "lot_id" INTEGER,
+    "date" DATE,
+    "average_weight" DOUBLE PRECISION,
+    "animal_count" INTEGER,
+    "note" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "lot_weighings_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateTable
@@ -121,6 +136,12 @@ CREATE INDEX "animals_lot_id_idx" ON "animals"("lot_id");
 CREATE INDEX "animals_sale_id_idx" ON "animals"("sale_id");
 
 -- CreateIndex
+CREATE INDEX "lots_plot_id_idx" ON "lots"("plot_id");
+
+-- CreateIndex
+CREATE INDEX "lot_weighings_lot_id_idx" ON "lot_weighings"("lot_id");
+
+-- CreateIndex
 CREATE INDEX "plot_evaluations_plot_id_idx" ON "plot_evaluations"("plot_id");
 
 -- CreateIndex
@@ -134,6 +155,12 @@ ALTER TABLE "animals" ADD CONSTRAINT "animals_lot_id_fkey" FOREIGN KEY ("lot_id"
 
 -- AddForeignKey
 ALTER TABLE "animals" ADD CONSTRAINT "animals_sale_id_fkey" FOREIGN KEY ("sale_id") REFERENCES "sales"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "lots" ADD CONSTRAINT "lots_plot_id_fkey" FOREIGN KEY ("plot_id") REFERENCES "plots"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "lot_weighings" ADD CONSTRAINT "lot_weighings_lot_id_fkey" FOREIGN KEY ("lot_id") REFERENCES "lots"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "plot_evaluations" ADD CONSTRAINT "plot_evaluations_plot_id_fkey" FOREIGN KEY ("plot_id") REFERENCES "plots"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,12 +57,32 @@ model Lot {
   number      String?
   name        String?
   description String?
+  plotId      Int?     @map("plot_id")
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @default(now()) @updatedAt @map("updated_at")
 
-  animals Animal[]
+  plot      Plot?         @relation(fields: [plotId], references: [id])
+  animals   Animal[]
+  weighings LotWeighing[]
 
+  @@index([plotId])
   @@map("lots")
+}
+
+model LotWeighing {
+  id            Int       @id @default(autoincrement())
+  lotId         Int?      @map("lot_id")
+  date          DateTime? @db.Date
+  averageWeight Float?    @map("average_weight")
+  animalCount   Int?      @map("animal_count")
+  note          String?
+  createdAt     DateTime  @default(now()) @map("created_at")
+  updatedAt     DateTime  @default(now()) @updatedAt @map("updated_at")
+
+  lot Lot? @relation(fields: [lotId], references: [id], onDelete: Cascade)
+
+  @@index([lotId])
+  @@map("lot_weighings")
 }
 
 model PlotEvaluation {
@@ -94,6 +114,7 @@ model Plot {
   updatedAt  DateTime @default(now()) @updatedAt @map("updated_at")
 
   evaluations PlotEvaluation[]
+  lots        Lot[]
 
   @@map("plots")
 }

--- a/src/actions/lotWeighings.ts
+++ b/src/actions/lotWeighings.ts
@@ -1,0 +1,63 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { prisma } from "@/lib/db";
+import { requireEditor, requireAdmin } from "@/lib/auth";
+import { str, int, float, date } from "@/actions/helpers";
+import { getWeightUnit, convertToKg } from "@/lib/units";
+
+async function weighingData(formData: FormData) {
+  const unit = await getWeightUnit();
+  // El peso promedio se captura en la unidad preferida; se almacena en kg.
+  const entered = float(formData.get("average_weight"));
+  return {
+    lotId: int(formData.get("lot_id")),
+    date: date(formData.get("date")),
+    averageWeight: convertToKg(entered, unit),
+    animalCount: int(formData.get("animal_count")),
+    note: str(formData.get("note")),
+  };
+}
+
+export async function createLotWeighing(formData: FormData) {
+  await requireEditor();
+  const weighing = await prisma.lotWeighing.create({
+    data: await weighingData(formData),
+  });
+  revalidatePath("/lots");
+  if (weighing.lotId) revalidatePath(`/lots/${weighing.lotId}`);
+  redirect(
+    weighing.lotId
+      ? `/lots/${weighing.lotId}?notice=Pesado registrado correctamente`
+      : `/lots?notice=Pesado registrado correctamente`,
+  );
+}
+
+export async function updateLotWeighing(id: number, formData: FormData) {
+  await requireEditor();
+  const weighing = await prisma.lotWeighing.update({
+    where: { id },
+    data: await weighingData(formData),
+  });
+  revalidatePath("/lots");
+  if (weighing.lotId) revalidatePath(`/lots/${weighing.lotId}`);
+  redirect(
+    weighing.lotId
+      ? `/lots/${weighing.lotId}?notice=Pesado actualizado correctamente`
+      : `/lots?notice=Pesado actualizado correctamente`,
+  );
+}
+
+export async function deleteLotWeighing(formData: FormData) {
+  await requireAdmin();
+  const id = Number(formData.get("id"));
+  const weighing = await prisma.lotWeighing.delete({ where: { id } });
+  revalidatePath("/lots");
+  if (weighing.lotId) revalidatePath(`/lots/${weighing.lotId}`);
+  redirect(
+    weighing.lotId
+      ? `/lots/${weighing.lotId}?notice=Pesado eliminado`
+      : `/lots?notice=Pesado eliminado`,
+  );
+}

--- a/src/actions/lots.ts
+++ b/src/actions/lots.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/db";
 import { requireEditor, requireAdmin } from "@/lib/auth";
-import { str } from "@/actions/helpers";
+import { str, int } from "@/actions/helpers";
 
 function lotData(formData: FormData) {
   return {
@@ -13,6 +13,7 @@ function lotData(formData: FormData) {
     number: str(formData.get("number")),
     name: str(formData.get("name")),
     description: str(formData.get("description")),
+    plotId: int(formData.get("plot_id")),
   };
 }
 

--- a/src/app/(app)/lot_weighings/[id]/edit/page.tsx
+++ b/src/app/(app)/lot_weighings/[id]/edit/page.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { prisma } from "@/lib/db";
+import { requireAdmin } from "@/lib/auth";
+import { getWeightUnit } from "@/lib/units";
+import { updateLotWeighing } from "@/actions/lotWeighings";
+import { LotWeighingForm } from "@/components/entity-forms/LotWeighingForm";
+import { ArrowLeftIcon } from "@/components/icons";
+
+export const dynamic = "force-dynamic";
+
+export default async function EditLotWeighingPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  await requireAdmin();
+  const { id } = await params;
+  const weighingId = Number(id);
+  if (Number.isNaN(weighingId)) notFound();
+
+  const [weighing, lots, unit] = await Promise.all([
+    prisma.lotWeighing.findUnique({ where: { id: weighingId } }),
+    prisma.lot.findMany({
+      orderBy: [{ ranch: "asc" }, { number: "asc" }],
+      select: { id: true, number: true, name: true, ranch: true, species: true },
+    }),
+    getWeightUnit(),
+  ]);
+  if (!weighing) notFound();
+
+  return (
+    <div>
+      <Link
+        href={weighing.lotId ? `/lots/${weighing.lotId}` : "/lots"}
+        className="mb-4 inline-flex items-center gap-1 text-sm font-medium text-slate-500 hover:text-slate-800"
+      >
+        <ArrowLeftIcon width={16} height={16} /> Volver
+      </Link>
+      <h1 className="mb-5 text-2xl font-bold tracking-tight text-slate-900">
+        Editar pesado de lote
+      </h1>
+      <LotWeighingForm
+        action={updateLotWeighing.bind(null, weighing.id)}
+        weighing={weighing}
+        lots={lots}
+        unit={unit}
+        submitLabel="Guardar cambios"
+      />
+    </div>
+  );
+}

--- a/src/app/(app)/lot_weighings/new/page.tsx
+++ b/src/app/(app)/lot_weighings/new/page.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+import { prisma } from "@/lib/db";
+import { requireEditor } from "@/lib/auth";
+import { getWeightUnit } from "@/lib/units";
+import { createLotWeighing } from "@/actions/lotWeighings";
+import { LotWeighingForm } from "@/components/entity-forms/LotWeighingForm";
+import { ArrowLeftIcon } from "@/components/icons";
+
+export const dynamic = "force-dynamic";
+
+export default async function NewLotWeighingPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ lot_id?: string }>;
+}) {
+  await requireEditor();
+  const { lot_id } = await searchParams;
+  const [lots, unit] = await Promise.all([
+    prisma.lot.findMany({
+      orderBy: [{ ranch: "asc" }, { number: "asc" }],
+      select: { id: true, number: true, name: true, ranch: true, species: true },
+    }),
+    getWeightUnit(),
+  ]);
+
+  return (
+    <div>
+      <Link
+        href={lot_id ? `/lots/${lot_id}` : "/lots"}
+        className="mb-4 inline-flex items-center gap-1 text-sm font-medium text-slate-500 hover:text-slate-800"
+      >
+        <ArrowLeftIcon width={16} height={16} /> Volver
+      </Link>
+      <h1 className="mb-5 text-2xl font-bold tracking-tight text-slate-900">
+        Registrar pesado de lote
+      </h1>
+      <LotWeighingForm
+        action={createLotWeighing}
+        lots={lots}
+        defaultLotId={lot_id ? Number(lot_id) : undefined}
+        unit={unit}
+        submitLabel="Registrar pesado"
+      />
+    </div>
+  );
+}

--- a/src/app/(app)/lots/[id]/edit/page.tsx
+++ b/src/app/(app)/lots/[id]/edit/page.tsx
@@ -17,11 +17,15 @@ export default async function EditLotPage({
   const { id } = await params;
   const lotId = Number(id);
   if (Number.isNaN(lotId)) notFound();
-  const [lot, haciendas] = await Promise.all([
+  const [lot, haciendas, plots] = await Promise.all([
     prisma.lot.findUnique({ where: { id: lotId } }),
     prisma.hacienda.findMany({
       orderBy: { name: "asc" },
       select: { id: true, name: true },
+    }),
+    prisma.plot.findMany({
+      orderBy: [{ ranch: "asc" }, { number: "asc" }],
+      select: { id: true, number: true, ranch: true, plotType: true },
     }),
   ]);
   if (!lot) notFound();
@@ -41,6 +45,7 @@ export default async function EditLotPage({
         action={updateLot.bind(null, lot.id)}
         lot={lot}
         haciendas={haciendas}
+        plots={plots}
         submitLabel="Guardar cambios"
       />
     </div>

--- a/src/app/(app)/lots/[id]/page.tsx
+++ b/src/app/(app)/lots/[id]/page.tsx
@@ -5,7 +5,16 @@ import { getCurrentUser, isAdmin, isEditor } from "@/lib/auth";
 import { deleteLot } from "@/actions/lots";
 import { Card, DescList, TableWrap, Th, Td, Badge, EmptyState } from "@/components/ui";
 import { DeleteButton } from "@/components/DeleteButton";
-import { ArrowLeftIcon, EditIcon, ChevronRightIcon, CowIcon } from "@/components/icons";
+import {
+  ArrowLeftIcon,
+  EditIcon,
+  ChevronRightIcon,
+  CowIcon,
+  PlusIcon,
+  ScaleIcon,
+} from "@/components/icons";
+import { fmtNumber, fmtDate } from "@/lib/utils";
+import { getWeightUnit, fmtWeight } from "@/lib/units";
 
 export const dynamic = "force-dynamic";
 
@@ -18,17 +27,25 @@ export default async function LotShowPage({
   const lotId = Number(id);
   if (Number.isNaN(lotId)) notFound();
 
-  const [lot, user] = await Promise.all([
+  const [lot, user, unit] = await Promise.all([
     prisma.lot.findUnique({
       where: { id: lotId },
-      include: { animals: { orderBy: { animalNumber: "asc" } } },
+      include: {
+        plot: true,
+        animals: { orderBy: { animalNumber: "asc" } },
+        weighings: { orderBy: [{ date: "desc" }, { id: "desc" }] },
+      },
     }),
     getCurrentUser(),
+    getWeightUnit(),
   ]);
   if (!lot) notFound();
 
   const canEdit = isEditor(user?.role);
   const canDelete = isAdmin(user?.role);
+
+  // El peso promedio y el número de animales del lote provienen del último pesado.
+  const latest = lot.weighings[0] ?? null;
 
   return (
     <div>
@@ -62,58 +79,151 @@ export default async function LotShowPage({
             items={[
               { label: "Número", value: lot.number ?? "—" },
               { label: "Hacienda", value: lot.ranch ?? "—" },
+              {
+                label: "Potrero",
+                value: lot.plot ? (
+                  <Link href={`/plots/${lot.plot.id}`} className="text-brand-600">
+                    {lot.plot.number
+                      ? `Potrero ${lot.plot.number}`
+                      : `#${lot.plot.id}`}
+                  </Link>
+                ) : (
+                  "—"
+                ),
+              },
               { label: "Especie", value: <span className="capitalize">{lot.species ?? "—"}</span> },
-              { label: "Animales", value: <Badge color="green">{lot.animals.length}</Badge> },
+              {
+                label: "Peso promedio",
+                value: fmtWeight(latest?.averageWeight ?? null, unit),
+              },
+              {
+                label: "Número de animales",
+                value:
+                  latest?.animalCount != null ? (
+                    <Badge color="green">{latest.animalCount}</Badge>
+                  ) : (
+                    "—"
+                  ),
+              },
+              { label: "Último pesado", value: fmtDate(latest?.date) },
+              { label: "Animales registrados", value: <Badge color="slate">{lot.animals.length}</Badge> },
               { label: "Descripción", value: lot.description ?? "—" },
             ]}
           />
         </Card>
 
-        <div className="lg:col-span-2">
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-400">
-            Animales del lote
-          </h2>
-          {lot.animals.length === 0 ? (
-            <EmptyState
-              icon={<CowIcon width={24} height={24} />}
-              title="Sin animales"
-              description="Asigna animales a este lote desde la ficha de cada animal."
-            />
-          ) : (
-            <TableWrap>
-              <thead>
-                <tr>
-                  <Th>#</Th>
-                  <Th>Especie</Th>
-                  <Th>Estatus</Th>
-                  <Th></Th>
-                </tr>
-              </thead>
-              <tbody>
-                {lot.animals.map((a) => (
-                  <tr key={a.id} className="hover:bg-slate-50">
-                    <Td className="font-semibold text-slate-900">
-                      {a.animalNumber ?? a.id}
-                    </Td>
-                    <Td className="capitalize">{a.species ?? "—"}</Td>
-                    <Td>
-                      <Badge color={a.status === "engorde" ? "green" : "slate"}>
-                        {a.status ?? "—"}
-                      </Badge>
-                    </Td>
-                    <Td>
-                      <Link
-                        href={`/animals/${a.id}`}
-                        className="inline-flex text-brand-600"
-                      >
-                        <ChevronRightIcon />
-                      </Link>
-                    </Td>
+        <div className="lg:col-span-2 space-y-8">
+          <div>
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-400">
+                Registros de pesado
+              </h2>
+              {canEdit && (
+                <Link
+                  href={`/lot_weighings/new?lot_id=${lot.id}`}
+                  className="inline-flex items-center gap-1 text-sm font-semibold text-brand-600 hover:text-brand-700"
+                >
+                  <PlusIcon width={16} height={16} /> Nuevo pesado
+                </Link>
+              )}
+            </div>
+
+            {lot.weighings.length === 0 ? (
+              <EmptyState
+                icon={<ScaleIcon width={24} height={24} />}
+                title="Sin pesados"
+                description="Registra el primer pesado del lote con su peso promedio y número de animales."
+                action={
+                  canEdit
+                    ? { href: `/lot_weighings/new?lot_id=${lot.id}`, label: "Nuevo pesado" }
+                    : undefined
+                }
+              />
+            ) : (
+              <TableWrap>
+                <thead>
+                  <tr>
+                    <Th>Fecha</Th>
+                    <Th className="text-right">Peso promedio</Th>
+                    <Th className="text-right">Animales</Th>
+                    <Th>Notas</Th>
+                    {canEdit && <Th></Th>}
                   </tr>
-                ))}
-              </tbody>
-            </TableWrap>
-          )}
+                </thead>
+                <tbody>
+                  {lot.weighings.map((w) => (
+                    <tr key={w.id} className="hover:bg-slate-50">
+                      <Td>{fmtDate(w.date)}</Td>
+                      <Td className="text-right font-semibold">
+                        {fmtWeight(w.averageWeight, unit)}
+                      </Td>
+                      <Td className="text-right">{w.animalCount ?? "—"}</Td>
+                      <Td className="max-w-xs truncate text-slate-500">
+                        {w.note ?? "—"}
+                      </Td>
+                      {canEdit && (
+                        <Td>
+                          <Link
+                            href={`/lot_weighings/${w.id}/edit`}
+                            className="text-brand-600 hover:text-brand-700"
+                          >
+                            <EditIcon width={16} height={16} />
+                          </Link>
+                        </Td>
+                      )}
+                    </tr>
+                  ))}
+                </tbody>
+              </TableWrap>
+            )}
+          </div>
+
+          <div>
+            <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-400">
+              Animales del lote
+            </h2>
+            {lot.animals.length === 0 ? (
+              <EmptyState
+                icon={<CowIcon width={24} height={24} />}
+                title="Sin animales"
+                description="Asigna animales a este lote desde la ficha de cada animal."
+              />
+            ) : (
+              <TableWrap>
+                <thead>
+                  <tr>
+                    <Th>#</Th>
+                    <Th>Especie</Th>
+                    <Th>Estatus</Th>
+                    <Th></Th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {lot.animals.map((a) => (
+                    <tr key={a.id} className="hover:bg-slate-50">
+                      <Td className="font-semibold text-slate-900">
+                        {a.animalNumber ?? a.id}
+                      </Td>
+                      <Td className="capitalize">{a.species ?? "—"}</Td>
+                      <Td>
+                        <Badge color={a.status === "engorde" ? "green" : "slate"}>
+                          {a.status ?? "—"}
+                        </Badge>
+                      </Td>
+                      <Td>
+                        <Link
+                          href={`/animals/${a.id}`}
+                          className="inline-flex text-brand-600"
+                        >
+                          <ChevronRightIcon />
+                        </Link>
+                      </Td>
+                    </tr>
+                  ))}
+                </tbody>
+              </TableWrap>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/(app)/lots/new/page.tsx
+++ b/src/app/(app)/lots/new/page.tsx
@@ -9,10 +9,16 @@ export const dynamic = "force-dynamic";
 
 export default async function NewLotPage() {
   await requireEditor();
-  const haciendas = await prisma.hacienda.findMany({
-    orderBy: { name: "asc" },
-    select: { id: true, name: true },
-  });
+  const [haciendas, plots] = await Promise.all([
+    prisma.hacienda.findMany({
+      orderBy: { name: "asc" },
+      select: { id: true, name: true },
+    }),
+    prisma.plot.findMany({
+      orderBy: [{ ranch: "asc" }, { number: "asc" }],
+      select: { id: true, number: true, ranch: true, plotType: true },
+    }),
+  ]);
   return (
     <div>
       <Link
@@ -24,7 +30,12 @@ export default async function NewLotPage() {
       <h1 className="mb-5 text-2xl font-bold tracking-tight text-slate-900">
         Nuevo lote
       </h1>
-      <LotForm action={createLot} haciendas={haciendas} submitLabel="Crear lote" />
+      <LotForm
+        action={createLot}
+        haciendas={haciendas}
+        plots={plots}
+        submitLabel="Crear lote"
+      />
     </div>
   );
 }

--- a/src/app/(app)/lots/page.tsx
+++ b/src/app/(app)/lots/page.tsx
@@ -1,24 +1,25 @@
 import Link from "next/link";
 import { prisma } from "@/lib/db";
-import { getLotStats } from "@/lib/queries";
 import { PageHeader, EmptyState, TableWrap, Th, Td, Card } from "@/components/ui";
 import { LotsIcon, ChevronRightIcon } from "@/components/icons";
-import { fmtNumber } from "@/lib/utils";
-import { getWeightUnit, convertFromKg, fmtWeight } from "@/lib/units";
+import { fmtNumber, fmtDate } from "@/lib/utils";
+import { getWeightUnit, fmtWeight } from "@/lib/units";
 
 export const dynamic = "force-dynamic";
 
 export default async function LotsPage() {
-  const [lots, stats, unit] = await Promise.all([
+  const [lots, unit] = await Promise.all([
     prisma.lot.findMany({
       orderBy: [{ ranch: "asc" }, { species: "asc" }, { number: "asc" }],
-      include: { _count: { select: { animals: true } } },
+      include: {
+        _count: { select: { animals: true } },
+        plot: { select: { id: true, number: true } },
+        // Último pesado del lote: define el peso promedio y el número de animales.
+        weighings: { orderBy: [{ date: "desc" }, { id: "desc" }], take: 1 },
+      },
     }),
-    getLotStats(),
     getWeightUnit(),
   ]);
-
-  const statByLot = new Map(stats.map((s) => [s.lot_id, s]));
 
   return (
     <div>
@@ -40,7 +41,7 @@ export default async function LotsPage() {
           {/* Tarjetas móvil */}
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:hidden">
             {lots.map((lot) => {
-              const s = statByLot.get(lot.id);
+              const latest = lot.weighings[0] ?? null;
               return (
                 <Link key={lot.id} href={`/lots/${lot.id}`}>
                   <Card className="p-4">
@@ -49,11 +50,15 @@ export default async function LotsPage() {
                         {lot.name || `Lote ${lot.number}`}
                       </p>
                       <span className="text-xs text-slate-400">
-                        {lot._count.animals} animales
+                        {latest?.animalCount ?? lot._count.animals} animales
                       </span>
                     </div>
                     <p className="text-xs text-slate-500">
-                      {[lot.ranch, lot.species, lot.number]
+                      {[
+                        lot.ranch,
+                        lot.species,
+                        lot.plot?.number ? `Potrero ${lot.plot.number}` : null,
+                      ]
                         .filter(Boolean)
                         .join(" · ")}
                     </p>
@@ -61,14 +66,12 @@ export default async function LotsPage() {
                       <div className="rounded-lg bg-slate-50 py-1.5">
                         <p className="text-xs text-slate-400">Peso prom.</p>
                         <p className="font-semibold">
-                          {fmtWeight(s?.average_weight ?? null, unit)}
+                          {fmtWeight(latest?.averageWeight ?? null, unit)}
                         </p>
                       </div>
                       <div className="rounded-lg bg-slate-50 py-1.5">
-                        <p className="text-xs text-slate-400">GDP</p>
-                        <p className="font-semibold">
-                          {fmtNumber(convertFromKg(s?.daily_gain ?? null, unit), 2)}
-                        </p>
+                        <p className="text-xs text-slate-400">Último pesado</p>
+                        <p className="font-semibold">{fmtDate(latest?.date)}</p>
                       </div>
                     </div>
                   </Card>
@@ -84,38 +87,34 @@ export default async function LotsPage() {
                 <tr>
                   <Th>Lote</Th>
                   <Th>Hacienda</Th>
+                  <Th>Potrero</Th>
                   <Th>Especie</Th>
                   <Th className="text-right">Animales</Th>
                   <Th className="text-right">Peso promedio</Th>
-                  <Th className="text-right">Cambio</Th>
-                  <Th className="text-right">GDP</Th>
-                  <Th className="text-right">Días sin pesar</Th>
+                  <Th className="text-right">Último pesado</Th>
                   <Th></Th>
                 </tr>
               </thead>
               <tbody>
                 {lots.map((lot) => {
-                  const s = statByLot.get(lot.id);
+                  const latest = lot.weighings[0] ?? null;
                   return (
                     <tr key={lot.id} className="hover:bg-slate-50">
                       <Td className="font-semibold text-slate-900">
                         {lot.name || lot.number || `#${lot.id}`}
                       </Td>
                       <Td>{lot.ranch ?? "—"}</Td>
+                      <Td>
+                        {lot.plot?.number ? `Potrero ${lot.plot.number}` : "—"}
+                      </Td>
                       <Td className="capitalize">{lot.species ?? "—"}</Td>
-                      <Td className="text-right">{lot._count.animals}</Td>
                       <Td className="text-right">
-                        {fmtWeight(s?.average_weight ?? null, unit)}
+                        {latest?.animalCount ?? lot._count.animals}
                       </Td>
                       <Td className="text-right">
-                        {fmtWeight(s?.weight_change ?? null, unit)}
+                        {fmtWeight(latest?.averageWeight ?? null, unit)}
                       </Td>
-                      <Td className="text-right">
-                        {fmtNumber(convertFromKg(s?.daily_gain ?? null, unit), 2)}
-                      </Td>
-                      <Td className="text-right">
-                        {fmtNumber(s?.days_since_last_weight ?? null)}
-                      </Td>
+                      <Td className="text-right">{fmtDate(latest?.date)}</Td>
                       <Td>
                         <Link
                           href={`/lots/${lot.id}`}

--- a/src/components/entity-forms/LotForm.tsx
+++ b/src/components/entity-forms/LotForm.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import type { Lot } from "@prisma/client";
+import type { Lot, Plot } from "@prisma/client";
 import { Card } from "@/components/ui";
 import { Field, Input, Select, Textarea, SubmitButton } from "@/components/forms";
 import { RanchSelect } from "@/components/RanchSelect";
@@ -10,11 +10,13 @@ export function LotForm({
   action,
   lot,
   haciendas,
+  plots,
   submitLabel,
 }: {
   action: (formData: FormData) => void | Promise<void>;
   lot?: Lot | null;
   haciendas: { id: number; name: string }[];
+  plots: Pick<Plot, "id" | "number" | "ranch" | "plotType">[];
   submitLabel: string;
 }) {
   return (
@@ -35,6 +37,17 @@ export function LotForm({
               {SPECIES.map((s) => (
                 <option key={s} value={s}>
                   {s}
+                </option>
+              ))}
+            </Select>
+          </Field>
+          <Field label="Potrero" hint="Ubicación del lote">
+            <Select name="plot_id" defaultValue={lot?.plotId ?? ""}>
+              <option value="">— Sin potrero —</option>
+              {plots.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {[p.ranch, p.plotType, p.number].filter(Boolean).join(" · ") ||
+                    `#${p.id}`}
                 </option>
               ))}
             </Select>

--- a/src/components/entity-forms/LotWeighingForm.tsx
+++ b/src/components/entity-forms/LotWeighingForm.tsx
@@ -1,0 +1,91 @@
+import Link from "next/link";
+import type { LotWeighing, Lot } from "@prisma/client";
+import { Card } from "@/components/ui";
+import { Field, Input, Select, Textarea, SubmitButton } from "@/components/forms";
+import { toDateInput } from "@/lib/utils";
+import type { WeightUnit } from "@/lib/units";
+import { convertFromKg } from "@/lib/units";
+
+export function LotWeighingForm({
+  action,
+  weighing,
+  lots,
+  defaultLotId,
+  unit,
+  submitLabel,
+}: {
+  action: (formData: FormData) => void | Promise<void>;
+  weighing?: LotWeighing | null;
+  lots: Pick<Lot, "id" | "number" | "name" | "ranch" | "species">[];
+  defaultLotId?: number;
+  unit: WeightUnit;
+  submitLabel: string;
+}) {
+  const selectedLot = weighing?.lotId ?? defaultLotId ?? "";
+  // El peso promedio almacenado está en kg; se muestra para edición en la unidad elegida.
+  const displayWeight =
+    weighing?.averageWeight != null
+      ? Math.round((convertFromKg(weighing.averageWeight, unit) ?? 0) * 10) / 10
+      : "";
+  return (
+    <form action={action}>
+      <Card className="space-y-5 p-5 sm:p-6">
+        <Field label="Lote">
+          <Select name="lot_id" defaultValue={selectedLot} required>
+            <option value="">— Selecciona un lote —</option>
+            {lots.map((l) => (
+              <option key={l.id} value={l.id}>
+                {[l.name || l.number || `#${l.id}`, l.ranch, l.species]
+                  .filter(Boolean)
+                  .join(" · ")}
+              </option>
+            ))}
+          </Select>
+        </Field>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <Field label="Fecha">
+            <Input
+              type="date"
+              name="date"
+              defaultValue={toDateInput(weighing?.date)}
+              required
+            />
+          </Field>
+          <Field
+            label="Peso promedio"
+            hint={unit === "lb" ? "libras" : "kilogramos"}
+          >
+            <Input
+              type="number"
+              step="0.1"
+              name="average_weight"
+              defaultValue={displayWeight}
+              required
+            />
+          </Field>
+        </div>
+        <Field label="Número de animales">
+          <Input
+            type="number"
+            step="1"
+            min="0"
+            name="animal_count"
+            defaultValue={weighing?.animalCount ?? ""}
+          />
+        </Field>
+        <Field label="Notas">
+          <Textarea name="note" defaultValue={weighing?.note ?? ""} />
+        </Field>
+        <div className="flex items-center gap-3 pt-1">
+          <SubmitButton>{submitLabel}</SubmitButton>
+          <Link
+            href={weighing?.lotId ? `/lots/${weighing.lotId}` : "/lots"}
+            className="rounded-xl px-4 py-2.5 text-sm font-semibold text-slate-600 hover:bg-slate-100"
+          >
+            Cancelar
+          </Link>
+        </div>
+      </Card>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive lot weighing management to the livestock tracking system. Users can now record periodic weight measurements for lots, track average weight and animal counts over time, and assign lots to specific plots (paddocks).

## Key Changes

### New Features
- **Lot Weighing Records**: New `LotWeighing` model to track historical weight data for each lot
  - Records date, average weight (stored in kg, displayed in user's preferred unit), animal count, and notes
  - Supports weight unit conversion (kg/lb) based on user preferences
  - Latest weighing data is displayed prominently on lot detail pages

- **Plot Assignment**: Lots can now be assigned to plots (paddocks)
  - Added `plot_id` foreign key to `Lot` model
  - Plot information displayed on lot detail and list pages with links to plot details

- **Lot Weighing UI Pages**:
  - New page to create lot weighing records (`/lot_weighings/new`)
  - Edit page for existing weighing records (`/lot_weighings/[id]/edit`)
  - Reusable `LotWeighingForm` component for create/edit operations

### Updated Pages
- **Lot Detail Page** (`/lots/[id]`):
  - New "Registros de pesado" (Weighing Records) section showing historical weight data in a table
  - Latest weighing data displayed in lot summary (average weight, animal count, last weighing date)
  - Plot assignment shown with link to plot details
  - Separated "Animales registrados" count from latest weighing animal count

- **Lots List Page** (`/lots`):
  - Added plot column to table view
  - Updated mobile cards to show latest weighing date instead of daily gain
  - Uses latest weighing data for weight and animal count displays

- **Lot Create/Edit Pages**:
  - Added plot selection field to lot form

### Database Changes
- New `lot_weighings` table with proper indexes and foreign key constraints
- Added `plot_id` column to `lots` table
- Updated Prisma schema with `LotWeighing` model and plot relationship

### Server Actions
- New `lotWeighings.ts` with `createLotWeighing`, `updateLotWeighing`, and `deleteLotWeighing` actions
- Proper authorization checks (editor for create/update, admin for delete)
- Weight unit conversion handled transparently during form submission

## Implementation Details
- Weight values are stored canonically in kilograms in the database but displayed/entered in the user's preferred unit
- Latest weighing is determined by sorting by date (descending) then ID (descending)
- Lot detail page queries weighings with proper ordering to efficiently get the latest record
- Form includes date picker, numeric inputs for weight and animal count, and optional notes field
- Proper cache revalidation on lot and list pages after weighing operations

https://claude.ai/code/session_01NHiY2w3mW6oz31pntmda6o