### PR TITLE
Add satellite map visualization for hacienda plots

### DIFF
--- a/src/app/(app)/haciendas/[id]/page.tsx
+++ b/src/app/(app)/haciendas/[id]/page.tsx
@@ -7,6 +7,8 @@ import { Card, DescList, StatCard } from "@/components/ui";
 import { DeleteButton } from "@/components/DeleteButton";
 import { ArrowLeftIcon, EditIcon, CowIcon, LotsIcon, PlotIcon } from "@/components/icons";
 import { fmtNumber } from "@/lib/utils";
+import { parseGeoJsonRing } from "@/lib/kml";
+import { HaciendaPlotsMap } from "@/components/HaciendaPlotsMap";
 
 export const dynamic = "force-dynamic";
 
@@ -25,11 +27,25 @@ export default async function HaciendaShowPage({
   ]);
   if (!hacienda) notFound();
 
-  const [animals, lots, plots] = await Promise.all([
+  const [animals, lots, plotRecords] = await Promise.all([
     prisma.animal.count({ where: { ranch: hacienda.name } }),
     prisma.lot.count({ where: { ranch: hacienda.name } }),
-    prisma.plot.count({ where: { ranch: hacienda.name } }),
+    prisma.plot.findMany({
+      where: { ranch: hacienda.name },
+      select: { id: true, number: true, boundaries: true },
+      orderBy: { number: "asc" },
+    }),
   ]);
+  const plots = plotRecords.length;
+
+  // Potreros con linderos válidos para dibujar en el mapa satelital.
+  const mapPlots = plotRecords
+    .map((p) => ({
+      id: p.id,
+      number: p.number,
+      ring: parseGeoJsonRing(p.boundaries),
+    }))
+    .filter((p): p is { id: number; number: string | null; ring: [number, number][] } => p.ring !== null);
 
   const canEdit = isEditor(user?.role);
   const canDelete = isAdmin(user?.role);
@@ -90,7 +106,7 @@ export default async function HaciendaShowPage({
         />
       </div>
 
-      <Card className="max-w-xl">
+      <Card className="mb-6 max-w-xl">
         <DescList
           items={[
             { label: "Nombre", value: hacienda.name },
@@ -99,6 +115,15 @@ export default async function HaciendaShowPage({
           ]}
         />
       </Card>
+
+      {mapPlots.length > 0 && (
+        <div>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-400">
+            Mapa de potreros
+          </h2>
+          <HaciendaPlotsMap plots={mapPlots} />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -59,3 +59,18 @@ body {
 .animate-slide-up {
   animation: slide-up 0.18s ease-out;
 }
+
+/* Etiqueta con el número del potrero sobre el mapa satelital. */
+.potrero-label {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  color: #fff;
+  font-weight: 700;
+  font-size: 12px;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.9), 0 0 2px rgba(0, 0, 0, 0.9);
+  padding: 0;
+}
+.potrero-label::before {
+  display: none;
+}

--- a/src/components/HaciendaPlotsMap.tsx
+++ b/src/components/HaciendaPlotsMap.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import "leaflet/dist/leaflet.css";
+
+export type HaciendaPlot = {
+  id: number;
+  number: string | null;
+  // Vértices en formato GeoJSON [lng, lat].
+  ring: [number, number][];
+};
+
+// Mapa satelital con los polígonos de todos los potreros de una hacienda.
+// Leaflet se carga de forma diferida (solo en el cliente) para evitar acceder a
+// `window` durante el SSR.
+export function HaciendaPlotsMap({ plots }: { plots: HaciendaPlot[] }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const drawable = plots.filter((p) => p.ring && p.ring.length >= 3);
+    if (drawable.length === 0) return;
+    let map: import("leaflet").Map | undefined;
+    let cancelled = false;
+
+    (async () => {
+      const L = (await import("leaflet")).default;
+      const el = containerRef.current;
+      if (!el || cancelled) return;
+      // Evita reinicializar sobre un contenedor ya usado (StrictMode).
+      if ((el as unknown as { _leaflet_id?: number })._leaflet_id) return;
+
+      map = L.map(el, {
+        scrollWheelZoom: false,
+        attributionControl: true,
+      });
+
+      // Imágenes satelitales (Esri World Imagery) — sin API key.
+      L.tileLayer(
+        "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+        {
+          maxZoom: 19,
+          attribution: "Imágenes &copy; Esri, Maxar, Earthstar Geographics",
+        },
+      ).addTo(map);
+
+      // Etiquetas de carreteras/lugares encima del satélite.
+      L.tileLayer(
+        "https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}",
+        { maxZoom: 19, opacity: 0.9 },
+      ).addTo(map);
+
+      const group = L.featureGroup();
+
+      for (const plot of drawable) {
+        // GeoJSON usa [lng, lat]; Leaflet usa [lat, lng].
+        const latlngs = plot.ring.map(
+          ([lng, lat]) => [lat, lng] as [number, number],
+        );
+        const polygon = L.polygon(latlngs, {
+          color: "#22c55e",
+          weight: 3,
+          fillColor: "#22c55e",
+          fillOpacity: 0.15,
+        });
+
+        const label = plot.number ? `Potrero ${plot.number}` : "Potrero";
+        // Etiqueta permanente con el número del potrero, centrada en el polígono.
+        polygon.bindTooltip(label, {
+          permanent: true,
+          direction: "center",
+          className: "potrero-label",
+        });
+        // Enlace a la página del potrero al hacer clic.
+        polygon.bindPopup(
+          `<a href="/plots/${plot.id}" style="color:#16a34a;font-weight:600;">${label} →</a>`,
+        );
+        polygon.addTo(group);
+      }
+
+      group.addTo(map);
+      map.fitBounds(group.getBounds(), { padding: [24, 24] });
+    })();
+
+    return () => {
+      cancelled = true;
+      if (map) map.remove();
+    };
+  }, [plots]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-80 w-full overflow-hidden rounded-2xl border border-slate-200 bg-slate-100 sm:h-[28rem]"
+    />
+  );
+}


### PR DESCRIPTION
## Summary
This PR adds an interactive satellite map to the hacienda detail page that visualizes all plots (potreros) with their boundaries as polygons. The map uses Leaflet with Esri satellite imagery and includes clickable plot labels and popups for navigation.

## Key Changes
- **New `HaciendaPlotsMap` component**: A client-side React component that renders an interactive Leaflet map with satellite imagery (Esri World Imagery) and overlay labels. The component:
  - Dynamically imports Leaflet only on the client to avoid SSR issues
  - Displays plot boundaries as green polygons with permanent labels
  - Includes clickable popups that link to individual plot pages
  - Auto-fits the map bounds to show all plots with padding
  - Handles cleanup and prevents reinitialization in StrictMode

- **Updated hacienda detail page** (`src/app/(app)/haciendas/[id]/page.tsx`):
  - Changed plot query from simple count to `findMany` to fetch plot details (id, number, boundaries)
  - Parses GeoJSON boundaries using `parseGeoJsonRing` utility
  - Filters plots to only include those with valid ring data for map rendering
  - Conditionally renders the map section only when drawable plots exist

- **Styling**: Added `.potrero-label` CSS class for permanent plot number labels with text shadow for visibility over satellite imagery

## Implementation Details
- GeoJSON coordinates are converted from `[lng, lat]` to Leaflet's `[lat, lng]` format
- Leaflet is lazy-loaded via dynamic import to maintain Next.js SSR compatibility
- Map uses `scrollWheelZoom: false` to prevent accidental zooming while scrolling
- Satellite layer is overlaid with a reference layer for road/place labels
- Cleanup function properly removes the map instance on component unmount

https://claude.ai/code/session_01F6nN1vhpSqpukny3YjZGG6