### PR TITLE
Número de animales por potrero y mapa de potreros en el dashboard

### DIFF
--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -1,8 +1,11 @@
+import { prisma } from "@/lib/db";
 import { getDashboardStats } from "@/lib/queries";
 import { getCurrentUser } from "@/lib/auth";
 import { getWeightUnit, convertFromKg, weightLabel, gainLabel } from "@/lib/units";
 import { StatCard, Card } from "@/components/ui";
-import { fmtNumber } from "@/lib/utils";
+import { fmtNumber, lotHeadcount } from "@/lib/utils";
+import { parseGeoJsonRing } from "@/lib/kml";
+import { PlotsOverviewMap, type PlotMarker } from "@/components/PlotsOverviewMap";
 import {
   CowIcon,
   ScaleIcon,
@@ -16,11 +19,46 @@ import {
 export const dynamic = "force-dynamic";
 
 export default async function DashboardPage() {
-  const [stats, user, unit] = await Promise.all([
+  const [stats, user, unit, plots] = await Promise.all([
     getDashboardStats(),
     getCurrentUser(),
     getWeightUnit(),
+    prisma.plot.findMany({
+      select: {
+        id: true,
+        number: true,
+        boundaries: true,
+        lots: {
+          select: {
+            _count: { select: { animals: true } },
+            weighings: {
+              orderBy: [{ date: "desc" }, { id: "desc" }],
+              take: 1,
+              select: { animalCount: true },
+            },
+          },
+        },
+      },
+    }),
   ]);
+
+  // Marcadores del mapa: potreros con geometría + número de animales en cada uno.
+  const plotMarkers: PlotMarker[] = plots
+    .map((p) => {
+      const ring = parseGeoJsonRing(p.boundaries);
+      if (!ring) return null;
+      const animalCount = p.lots.reduce(
+        (sum, lot) => sum + lotHeadcount(lot),
+        0,
+      );
+      return {
+        id: p.id,
+        label: `Potrero ${p.number ?? p.id}`,
+        ring,
+        animalCount,
+      };
+    })
+    .filter((m): m is PlotMarker => m !== null);
 
   return (
     <div>
@@ -102,6 +140,24 @@ export default async function DashboardPage() {
             href="/sales"
           />
         </div>
+      </section>
+
+      <section className="mt-8">
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-400">
+          Mapa de potreros
+        </h2>
+        {plotMarkers.length === 0 ? (
+          <Card className="p-5">
+            <p className="text-sm text-slate-500">
+              Aún no hay potreros con geometría para mostrar en el mapa. Importa
+              tus potreros desde un archivo KMZ en{" "}
+              <span className="font-semibold text-slate-700">Potreros</span> para
+              verlos aquí con el número de animales en cada uno.
+            </p>
+          </Card>
+        ) : (
+          <PlotsOverviewMap plots={plotMarkers} />
+        )}
       </section>
 
       <Card className="mt-8 p-5">

--- a/src/app/(app)/plots/[id]/page.tsx
+++ b/src/app/(app)/plots/[id]/page.tsx
@@ -3,10 +3,10 @@ import { notFound } from "next/navigation";
 import { prisma } from "@/lib/db";
 import { getCurrentUser, isAdmin, isEditor } from "@/lib/auth";
 import { deletePlot } from "@/actions/plots";
-import { Card, DescList, TableWrap, Th, Td, EmptyState } from "@/components/ui";
+import { Card, DescList, TableWrap, Th, Td, Badge, EmptyState } from "@/components/ui";
 import { DeleteButton } from "@/components/DeleteButton";
 import { ArrowLeftIcon, EditIcon, PlusIcon, CalendarIcon } from "@/components/icons";
-import { fmtNumber, fmtDate } from "@/lib/utils";
+import { fmtNumber, fmtDate, lotHeadcount } from "@/lib/utils";
 import { parseGeoJsonRing } from "@/lib/kml";
 import { PlotMap } from "@/components/PlotMap";
 
@@ -24,7 +24,19 @@ export default async function PlotShowPage({
   const [plot, user] = await Promise.all([
     prisma.plot.findUnique({
       where: { id: plotId },
-      include: { evaluations: { orderBy: { date: "desc" } } },
+      include: {
+        evaluations: { orderBy: { date: "desc" } },
+        lots: {
+          select: {
+            _count: { select: { animals: true } },
+            weighings: {
+              orderBy: [{ date: "desc" }, { id: "desc" }],
+              take: 1,
+              select: { animalCount: true },
+            },
+          },
+        },
+      },
     }),
     getCurrentUser(),
   ]);
@@ -34,12 +46,19 @@ export default async function PlotShowPage({
   const canDelete = isAdmin(user?.role);
   const ring = parseGeoJsonRing(plot.boundaries);
 
+  // Animales en el potrero: suma del número de animales de los lotes ubicados aquí.
+  const animalCount = plot.lots.reduce((sum, lot) => sum + lotHeadcount(lot), 0);
+
   const details = [
     { label: "Número", value: plot.number ?? "—" },
     { label: "Hacienda", value: plot.ranch ?? "—" },
     {
       label: "Tipo",
       value: <span className="capitalize">{plot.plotType ?? "—"}</span>,
+    },
+    {
+      label: "Animales",
+      value: <Badge color="green">{fmtNumber(animalCount)}</Badge>,
     },
     { label: "Área", value: plot.area ? `${fmtNumber(plot.area, 2)} ha` : "—" },
     { label: "Comentario", value: plot.comment ?? "—" },

--- a/src/components/PlotsOverviewMap.tsx
+++ b/src/components/PlotsOverviewMap.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import "leaflet/dist/leaflet.css";
+
+export type PlotMarker = {
+  id: number;
+  label: string;
+  // Anillo exterior en formato GeoJSON [lng, lat].
+  ring: [number, number][];
+  animalCount: number;
+};
+
+// Mapa satelital con TODOS los potreros dibujados y, en el centro de cada uno,
+// un círculo con el número de animales que hay en ese potrero. Leaflet se carga
+// de forma diferida (solo en el cliente) para evitar acceder a `window` en SSR.
+export function PlotsOverviewMap({ plots }: { plots: PlotMarker[] }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const usable = plots.filter((p) => p.ring && p.ring.length >= 3);
+    if (usable.length === 0) return;
+    let map: import("leaflet").Map | undefined;
+    let cancelled = false;
+
+    (async () => {
+      const L = (await import("leaflet")).default;
+      const el = containerRef.current;
+      if (!el || cancelled) return;
+      // Evita reinicializar sobre un contenedor ya usado (StrictMode).
+      if ((el as unknown as { _leaflet_id?: number })._leaflet_id) return;
+
+      map = L.map(el, { scrollWheelZoom: false, attributionControl: true });
+
+      // Imágenes satelitales (Esri World Imagery) — sin API key.
+      L.tileLayer(
+        "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+        {
+          maxZoom: 19,
+          attribution: "Imágenes &copy; Esri, Maxar, Earthstar Geographics",
+        },
+      ).addTo(map);
+
+      // Etiquetas de carreteras/lugares encima del satélite.
+      L.tileLayer(
+        "https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}",
+        { maxZoom: 19, opacity: 0.9 },
+      ).addTo(map);
+
+      const bounds = L.latLngBounds([]);
+
+      for (const p of usable) {
+        // GeoJSON usa [lng, lat]; Leaflet usa [lat, lng].
+        const latlngs = p.ring.map(
+          ([lng, lat]) => [lat, lng] as [number, number],
+        );
+        const polygon = L.polygon(latlngs, {
+          color: "#22c55e",
+          weight: 2,
+          fillColor: "#22c55e",
+          fillOpacity: 0.12,
+        }).addTo(map!);
+
+        const pBounds = polygon.getBounds();
+        bounds.extend(pBounds);
+
+        // Círculo con el número de animales en el centro del potrero.
+        const hasAnimals = p.animalCount > 0;
+        const bg = hasAnimals ? "#16a34a" : "#94a3b8";
+        const icon = L.divIcon({
+          className: "plot-count-marker",
+          html: `<div style="display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:9999px;background:${bg};color:#fff;font-weight:700;font-size:13px;border:2px solid #fff;box-shadow:0 1px 4px rgba(0,0,0,0.4);">${p.animalCount}</div>`,
+          iconSize: [36, 36],
+          iconAnchor: [18, 18],
+        });
+        L.marker(pBounds.getCenter(), { icon })
+          .addTo(map!)
+          .bindPopup(`<b>${p.label}</b><br/>${p.animalCount} animales`);
+      }
+
+      if (bounds.isValid()) map.fitBounds(bounds, { padding: [30, 30] });
+    })();
+
+    return () => {
+      cancelled = true;
+      if (map) map.remove();
+    };
+  }, [plots]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-80 w-full overflow-hidden rounded-2xl border border-slate-200 bg-slate-100 sm:h-96"
+    />
+  );
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -63,3 +63,14 @@ export function toNum(value: unknown): number | null {
 export function classNames(...classes: (string | false | null | undefined)[]) {
   return classes.filter(Boolean).join(" ");
 }
+
+// Número de animales de un lote: se toma del último pesado (animalCount); si el
+// lote aún no tiene pesados, se usa el conteo de animales registrados.
+export function lotHeadcount(lot: {
+  weighings: { animalCount: number | null }[];
+  _count?: { animals: number };
+}): number {
+  const latest = lot.weighings[0];
+  if (latest?.animalCount != null) return latest.animalCount;
+  return lot._count?.animals ?? 0;
+}


### PR DESCRIPTION
## Resumen

- **Página del potrero** (`/plots/[id]`): nueva fila **"Animales"** con el número de animales que hay en el potrero. Se calcula sumando el número de animales de los lotes ubicados en ese potrero (tomado del último pesado de cada lote, con respaldo al conteo de animales registrados si el lote aún no tiene pesados).
- **Dashboard**: nueva sección **"Mapa de potreros"** con un mapa satelital (Esri) que dibuja todos los potreros con geometría. En el centro de cada uno se dibuja un **círculo con el número de animales** (verde si tiene animales, gris si está en cero) y un popup con el nombre del potrero y el conteo. Si no hay potreros con geometría, se muestra un mensaje guía.

## Detalles de implementación

- Nuevo componente cliente `src/components/PlotsOverviewMap.tsx` (Leaflet cargado de forma diferida, mismo enfoque satelital que `PlotMap`/`HaciendaPlotsMap`).
- Helper compartido `lotHeadcount` en `lib/utils.ts` para el conteo de animales por lote (último pesado → respaldo a animales registrados).
- No requiere cambios en la base de datos: solo lee datos existentes.

https://claude.ai/code/session_01NHiY2w3mW6oz31pntmda6o

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHiY2w3mW6oz31pntmda6o)_