### PR TITLE
Selector de hacienda en la barra lateral con filtro global

### DIFF
--- a/src/app/(app)/animals/page.tsx
+++ b/src/app/(app)/animals/page.tsx
@@ -4,6 +4,7 @@ import { PageHeader, Card, EmptyState, Badge, TableWrap, Th, Td } from "@/compon
 import { CowIcon, SearchIcon, ChevronRightIcon } from "@/components/icons";
 import { fmtNumber } from "@/lib/utils";
 import { getWeightUnit, convertFromKg, fmtWeight } from "@/lib/units";
+import { getActiveHacienda } from "@/lib/activeHacienda";
 
 export const dynamic = "force-dynamic";
 
@@ -30,9 +31,13 @@ export default async function AnimalsPage({
 }) {
   const sp = await searchParams;
   const page = Math.max(1, parseInt(sp.page ?? "1", 10) || 1);
-  const unit = await getWeightUnit();
+  const [unit, activeHacienda] = await Promise.all([
+    getWeightUnit(),
+    getActiveHacienda(),
+  ]);
   const { rows, total } = await getLatestWeights({
     search: sp.search,
+    ranch: activeHacienda ?? undefined,
     sort: sp.sort,
     direction: sp.direction,
     page,
@@ -59,7 +64,9 @@ export default async function AnimalsPage({
     <div>
       <PageHeader
         title="Animales"
-        subtitle={`${fmtNumber(total)} en engorde · pesos más recientes`}
+        subtitle={`${fmtNumber(total)} en engorde · pesos más recientes${
+          activeHacienda ? ` · ${activeHacienda}` : ""
+        }`}
         action={{ href: "/animals/new", label: "Nuevo animal" }}
       />
 

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,6 +1,8 @@
 import { Suspense } from "react";
 import { getCurrentUser } from "@/lib/auth";
 import { getWeightUnit } from "@/lib/units";
+import { getActiveHacienda } from "@/lib/activeHacienda";
+import { prisma } from "@/lib/db";
 import { AppShell } from "@/components/AppShell";
 import { Flash } from "@/components/Flash";
 
@@ -9,12 +11,22 @@ export default async function AppLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const [user, weightUnit] = await Promise.all([
+  const [user, weightUnit, activeHacienda, haciendas] = await Promise.all([
     getCurrentUser(),
     getWeightUnit(),
+    getActiveHacienda(),
+    prisma.hacienda.findMany({
+      select: { id: true, name: true },
+      orderBy: { name: "asc" },
+    }),
   ]);
   return (
-    <AppShell user={user} weightUnit={weightUnit}>
+    <AppShell
+      user={user}
+      weightUnit={weightUnit}
+      haciendas={haciendas}
+      activeHacienda={activeHacienda}
+    >
       <Suspense fallback={null}>
         <Flash />
       </Suspense>

--- a/src/app/(app)/lots/page.tsx
+++ b/src/app/(app)/lots/page.tsx
@@ -4,12 +4,15 @@ import { PageHeader, EmptyState, TableWrap, Th, Td, Card } from "@/components/ui
 import { LotsIcon, ChevronRightIcon } from "@/components/icons";
 import { fmtNumber, fmtDate } from "@/lib/utils";
 import { getWeightUnit, fmtWeight } from "@/lib/units";
+import { getActiveHacienda } from "@/lib/activeHacienda";
 
 export const dynamic = "force-dynamic";
 
 export default async function LotsPage() {
+  const activeHacienda = await getActiveHacienda();
   const [lots, unit] = await Promise.all([
     prisma.lot.findMany({
+      where: activeHacienda ? { ranch: activeHacienda } : undefined,
       orderBy: [{ ranch: "asc" }, { species: "asc" }, { number: "asc" }],
       include: {
         _count: { select: { animals: true } },
@@ -25,7 +28,9 @@ export default async function LotsPage() {
     <div>
       <PageHeader
         title="Lotes"
-        subtitle={`${fmtNumber(lots.length)} lotes registrados`}
+        subtitle={`${fmtNumber(lots.length)} lotes registrados${
+          activeHacienda ? ` · ${activeHacienda}` : ""
+        }`}
         action={{ href: "/lots/new", label: "Nuevo lote" }}
       />
 

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/db";
 import { getDashboardStats } from "@/lib/queries";
 import { getCurrentUser } from "@/lib/auth";
 import { getWeightUnit, convertFromKg, weightLabel, gainLabel } from "@/lib/units";
+import { getActiveHacienda } from "@/lib/activeHacienda";
 import { StatCard, Card } from "@/components/ui";
 import { fmtNumber, lotHeadcount } from "@/lib/utils";
 import { parseGeoJsonRing } from "@/lib/kml";
@@ -19,11 +20,13 @@ import {
 export const dynamic = "force-dynamic";
 
 export default async function DashboardPage() {
+  const activeHacienda = await getActiveHacienda();
   const [stats, user, unit, plots] = await Promise.all([
-    getDashboardStats(),
+    getDashboardStats(activeHacienda ?? undefined),
     getCurrentUser(),
     getWeightUnit(),
     prisma.plot.findMany({
+      where: activeHacienda ? { ranch: activeHacienda } : undefined,
       select: {
         id: true,
         number: true,
@@ -67,7 +70,9 @@ export default async function DashboardPage() {
           Hola{user?.firstName ? `, ${user.firstName}` : ""} 👋
         </h1>
         <p className="mt-0.5 text-sm text-slate-500">
-          Resumen general de tu operación ganadera
+          {activeHacienda
+            ? `Resumen de ${activeHacienda}`
+            : "Resumen general de tu operación ganadera"}
         </p>
       </div>
 

--- a/src/app/(app)/plots/page.tsx
+++ b/src/app/(app)/plots/page.tsx
@@ -4,6 +4,7 @@ import { getLatestPlotScores } from "@/lib/queries";
 import { EmptyState, TableWrap, Th, Td, Card, Badge } from "@/components/ui";
 import { PlotIcon, ChevronRightIcon, PlusIcon } from "@/components/icons";
 import { fmtNumber } from "@/lib/utils";
+import { getActiveHacienda } from "@/lib/activeHacienda";
 
 export const dynamic = "force-dynamic";
 
@@ -15,8 +16,10 @@ function scoreColor(avg: number | null): "green" | "amber" | "red" | "slate" {
 }
 
 export default async function PlotsPage() {
+  const activeHacienda = await getActiveHacienda();
   const [plots, scores] = await Promise.all([
     prisma.plot.findMany({
+      where: activeHacienda ? { ranch: activeHacienda } : undefined,
       orderBy: [{ ranch: "asc" }, { number: "asc" }],
       include: { _count: { select: { evaluations: true } } },
     }),
@@ -33,6 +36,7 @@ export default async function PlotsPage() {
           </h1>
           <p className="mt-0.5 text-sm text-slate-500">
             {fmtNumber(plots.length)} potreros registrados
+            {activeHacienda ? ` · ${activeHacienda}` : ""}
           </p>
         </div>
         <div className="flex items-center gap-2">

--- a/src/app/(app)/sales/page.tsx
+++ b/src/app/(app)/sales/page.tsx
@@ -5,6 +5,7 @@ import { PageHeader, EmptyState, TableWrap, Th, Td, Card, Badge } from "@/compon
 import { MoneyIcon, ChevronRightIcon } from "@/components/icons";
 import { fmtNumber, fmtDate, fmtMoney, fmtPercent } from "@/lib/utils";
 import { getWeightUnit, fmtWeight } from "@/lib/units";
+import { getActiveHacienda } from "@/lib/activeHacienda";
 
 export const dynamic = "force-dynamic";
 
@@ -14,12 +15,16 @@ function roiColor(roi: number | null): "green" | "red" | "slate" {
 }
 
 export default async function SalesPage() {
+  const activeHacienda = await getActiveHacienda();
   const [sales, stats] = await Promise.all([
     prisma.sale.findMany({
+      where: activeHacienda
+        ? { animals: { some: { ranch: activeHacienda } } }
+        : undefined,
       orderBy: { date: "desc" },
       include: { _count: { select: { animals: true } } },
     }),
-    getSaleStats(),
+    getSaleStats(activeHacienda ?? undefined),
   ]);
   const unit = await getWeightUnit();
   const statBySale = new Map(stats.map((s) => [s.sale_id, s]));
@@ -28,7 +33,9 @@ export default async function SalesPage() {
     <div>
       <PageHeader
         title="Ventas"
-        subtitle={`${fmtNumber(sales.length)} ventas registradas`}
+        subtitle={`${fmtNumber(sales.length)} ventas registradas${
+          activeHacienda ? ` · ${activeHacienda}` : ""
+        }`}
         action={{ href: "/sales/new", label: "Nueva venta" }}
       />
 

--- a/src/app/(app)/weights/page.tsx
+++ b/src/app/(app)/weights/page.tsx
@@ -4,12 +4,15 @@ import { PageHeader, EmptyState, TableWrap, Th, Td } from "@/components/ui";
 import { ScaleIcon, ChevronRightIcon } from "@/components/icons";
 import { fmtDate } from "@/lib/utils";
 import { getWeightUnit, fmtWeight } from "@/lib/units";
+import { getActiveHacienda } from "@/lib/activeHacienda";
 
 export const dynamic = "force-dynamic";
 
 export default async function WeightsPage() {
+  const activeHacienda = await getActiveHacienda();
   const [weights, unit] = await Promise.all([
     prisma.weight.findMany({
+      where: activeHacienda ? { animal: { ranch: activeHacienda } } : undefined,
       orderBy: { date: "desc" },
       take: 200,
       include: { animal: true },
@@ -21,7 +24,9 @@ export default async function WeightsPage() {
     <div>
       <PageHeader
         title="Pesos"
-        subtitle="Últimos registros de peso"
+        subtitle={`Últimos registros de peso${
+          activeHacienda ? ` · ${activeHacienda}` : ""
+        }`}
         action={{ href: "/weights/new", label: "Registrar peso" }}
       />
 

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 import { classNames } from "@/lib/utils";
 import type { SessionUser } from "@/lib/auth";
 import { UnitToggle } from "@/components/UnitToggle";
+import { HaciendaSwitcher } from "@/components/HaciendaSwitcher";
 import {
   DashboardIcon,
   CowIcon,
@@ -24,7 +25,6 @@ const SIDEBAR_STORAGE_KEY = "sidebar-collapsed";
 
 const NAV = [
   { href: "/", label: "Tablero", Icon: DashboardIcon, exact: true },
-  { href: "/haciendas", label: "Haciendas", Icon: LeafIcon },
   { href: "/animals", label: "Animales", Icon: CowIcon },
   { href: "/lots", label: "Lotes", Icon: LotsIcon },
   { href: "/plots", label: "Potreros", Icon: PlotIcon },
@@ -43,10 +43,14 @@ function isActive(pathname: string, href: string, exact?: boolean) {
 export function AppShell({
   user,
   weightUnit,
+  haciendas,
+  activeHacienda,
   children,
 }: {
   user: SessionUser | null;
   weightUnit: "kg" | "lb";
+  haciendas: { id: number; name: string }[];
+  activeHacienda: string | null;
   children: React.ReactNode;
 }) {
   const pathname = usePathname();
@@ -86,6 +90,7 @@ export function AppShell({
             <SidebarIcon width={20} height={20} />
           </button>
         </div>
+        <HaciendaSwitcher haciendas={haciendas} active={activeHacienda} />
         <nav className="flex-1 space-y-1 px-3 py-4">
           {NAV.map(({ href, label, Icon, exact }) => (
             <Link
@@ -142,6 +147,11 @@ export function AppShell({
                 <CloseIcon />
               </button>
             </div>
+            <HaciendaSwitcher
+              haciendas={haciendas}
+              active={activeHacienda}
+              onNavigate={() => setOpen(false)}
+            />
             <nav className="flex-1 space-y-1 px-3 py-4">
               {NAV.map(({ href, label, Icon, exact }) => (
                 <Link

--- a/src/components/HaciendaSwitcher.tsx
+++ b/src/components/HaciendaSwitcher.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { classNames } from "@/lib/utils";
+import { ACTIVE_HACIENDA_COOKIE } from "@/lib/activeHacienda";
+import {
+  LeafIcon,
+  ChevronDownIcon,
+  CheckIcon,
+  SettingsIcon,
+} from "@/components/icons";
+
+const ALL_LABEL = "Todas las haciendas";
+
+// Selector de la hacienda activa para la barra lateral. Guarda el nombre elegido
+// en una cookie legible por el servidor y refresca para que los componentes
+// server re-rendericen. Incluye un acceso a "Hacienda Admin" para crear y
+// configurar haciendas.
+export function HaciendaSwitcher({
+  haciendas,
+  active,
+  onNavigate,
+}: {
+  haciendas: { id: number; name: string }[];
+  active: string | null;
+  onNavigate?: () => void;
+}) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Cierra el menú al hacer clic fuera o presionar Escape.
+  useEffect(() => {
+    if (!open) return;
+    function onClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  // El valor activo puede ser un nombre heredado que ya no existe en la lista.
+  const known = active && haciendas.some((h) => h.name === active);
+  const currentLabel = active ?? ALL_LABEL;
+
+  function choose(name: string | null) {
+    setOpen(false);
+    const value = name ?? "";
+    document.cookie = `${ACTIVE_HACIENDA_COOKIE}=${encodeURIComponent(
+      value,
+    )}; path=/; max-age=31536000; samesite=lax`;
+    router.refresh();
+  }
+
+  return (
+    <div className="relative px-3 pb-1" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-2.5 rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-left transition hover:border-slate-300 hover:bg-slate-50"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-brand-50 text-brand-600">
+          <LeafIcon width={18} height={18} />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block text-[11px] font-medium uppercase tracking-wide text-slate-400">
+            Hacienda
+          </span>
+          <span className="block truncate text-sm font-semibold text-slate-900">
+            {currentLabel}
+            {active && !known ? " (sin registrar)" : ""}
+          </span>
+        </span>
+        <ChevronDownIcon
+          width={18}
+          height={18}
+          className={classNames(
+            "shrink-0 text-slate-400 transition-transform",
+            open && "rotate-180",
+          )}
+        />
+      </button>
+
+      {open && (
+        <div
+          className="absolute inset-x-3 z-50 mt-1 overflow-hidden rounded-xl border border-slate-200 bg-white py-1 shadow-lg"
+          role="listbox"
+        >
+          <div className="max-h-64 overflow-y-auto">
+            <OptionRow
+              label={ALL_LABEL}
+              selected={!active}
+              onClick={() => choose(null)}
+            />
+            {haciendas.map((h) => (
+              <OptionRow
+                key={h.id}
+                label={h.name}
+                selected={active === h.name}
+                onClick={() => choose(h.name)}
+              />
+            ))}
+            {active && !known && (
+              <OptionRow
+                label={`${active} (sin registrar)`}
+                selected
+                onClick={() => choose(active)}
+              />
+            )}
+          </div>
+          <div className="my-1 border-t border-slate-100" />
+          <Link
+            href="/haciendas"
+            onClick={() => {
+              setOpen(false);
+              onNavigate?.();
+            }}
+            className="flex items-center gap-2.5 px-3 py-2 text-sm font-semibold text-brand-700 transition hover:bg-brand-50"
+          >
+            <SettingsIcon width={18} height={18} />
+            Hacienda Admin
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function OptionRow({
+  label,
+  selected,
+  onClick,
+}: {
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={selected}
+      onClick={onClick}
+      className={classNames(
+        "flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition",
+        selected
+          ? "bg-brand-50 font-semibold text-brand-700"
+          : "text-slate-600 hover:bg-slate-50",
+      )}
+    >
+      <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+        {selected && <CheckIcon width={16} height={16} />}
+      </span>
+      <span className="truncate">{label}</span>
+    </button>
+  );
+}

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -136,6 +136,22 @@ export function ChevronRightIcon(p: IconProps) {
   );
 }
 
+export function ChevronDownIcon(p: IconProps) {
+  return (
+    <svg {...base} {...p}>
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
+}
+
+export function CheckIcon(p: IconProps) {
+  return (
+    <svg {...base} {...p}>
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
 export function ArrowLeftIcon(p: IconProps) {
   return (
     <svg {...base} {...p}>

--- a/src/lib/activeHacienda.ts
+++ b/src/lib/activeHacienda.ts
@@ -1,0 +1,13 @@
+import { cookies } from "next/headers";
+
+// Hacienda "activa" seleccionada en la barra lateral. Se guarda el NOMBRE en una
+// cookie legible por el servidor (igual que la unidad de peso) para que pueda
+// usarse como contexto/predeterminado en toda la app. Valor vacío = todas.
+
+export const ACTIVE_HACIENDA_COOKIE = "active_hacienda";
+
+export async function getActiveHacienda(): Promise<string | null> {
+  const store = await cookies();
+  const value = store.get(ACTIVE_HACIENDA_COOKIE)?.value?.trim();
+  return value ? value : null;
+}

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -140,6 +140,7 @@ const SORT_COLUMNS: Record<string, string> = {
 // Replica Animal.latest_weights + search + sort + paginate + growing (engorde).
 export async function getLatestWeights(opts: {
   search?: string;
+  ranch?: string;
   sort?: string;
   direction?: string;
   page?: number;
@@ -169,11 +170,21 @@ export async function getLatestWeights(opts: {
     WHERE animals.status = 'engorde'
   `;
 
+  // Cláusulas de filtro con placeholders numerados según el orden de `params`.
+  const params: unknown[] = [];
+  let filterClause = "";
+
   const search = opts.search?.trim();
-  const searchClause = search
-    ? ` AND (CAST(animals.animal_number AS text) = $1 OR animals.species ILIKE $1 OR animals.ranch ILIKE $1)`
-    : "";
-  const params: unknown[] = search ? [search] : [];
+  if (search) {
+    params.push(search);
+    filterClause += ` AND (CAST(animals.animal_number AS text) = $${params.length} OR animals.species ILIKE $${params.length} OR animals.ranch ILIKE $${params.length})`;
+  }
+
+  const ranch = opts.ranch?.trim();
+  if (ranch) {
+    params.push(ranch);
+    filterClause += ` AND animals.ranch = $${params.length}`;
+  }
 
   const selectSql = `
     SELECT
@@ -195,12 +206,12 @@ export async function getLatestWeights(opts: {
       animals.status AS status,
       animals.purchase_price AS purchase_price,
       animals.provider AS provider
-    ${base}${searchClause}
+    ${base}${filterClause}
     ORDER BY ${orderBy} ${direction}
     LIMIT ${perPage} OFFSET ${offset}
   `;
 
-  const countSql = `SELECT COUNT(*)::float8 AS total ${base}${searchClause}`;
+  const countSql = `SELECT COUNT(*)::float8 AS total ${base}${filterClause}`;
 
   const rows = await prisma.$queryRawUnsafe<LatestWeightRow[]>(
     selectSql,

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -19,11 +19,19 @@ export type DashboardStats = {
   totalSales: number;
 };
 
-export async function getDashboardStats(): Promise<DashboardStats> {
+export async function getDashboardStats(
+  ranch?: string,
+): Promise<DashboardStats> {
+  // Filtro opcional por hacienda activa (placeholder $1 sobre animals.ranch).
+  const activeRanch = ranch?.trim() || undefined;
+  const ranchClause = activeRanch ? ` AND animals.ranch = $1` : "";
+  const params: unknown[] = activeRanch ? [activeRanch] : [];
+
   // Peso promedio y conteo por especie (solo animales en engorde).
   const avgWeight = await prisma.$queryRawUnsafe<
     { species: string; count: number; average_weight: number }[]
-  >(`
+  >(
+    `
     SELECT animals.species AS species,
            COUNT(DISTINCT animals.id)::float8 AS count,
            AVG(weights.weight)::float8 AS average_weight
@@ -40,14 +48,17 @@ export async function getDashboardStats(): Promise<DashboardStats> {
       GROUP BY animal_id
     ) AS dates ON weights.animal_id = dates.animal_id AND weights.date = dates.latest_date
     JOIN weights w2 ON w2.animal_id = dates.animal_id AND w2.date = dates.before_date
-    WHERE animals.status = 'engorde'
+    WHERE animals.status = 'engorde'${ranchClause}
     GROUP BY animals.species
-  `);
+  `,
+    ...params,
+  );
 
   // Ganancia diaria de peso (GDP) por especie.
   const dailyGain = await prisma.$queryRawUnsafe<
     { species: string; daily_gain: number }[]
-  >(`
+  >(
+    `
     SELECT animals.species AS species,
            AVG(COALESCE((weights.weight - w2.weight) / NULLIF((dates.latest_date - dates.before_date), 0), 0))::float8 AS daily_gain
     FROM animals
@@ -64,14 +75,17 @@ export async function getDashboardStats(): Promise<DashboardStats> {
     ) AS dates ON weights.animal_id = dates.animal_id AND weights.date = dates.latest_date
     JOIN weights w2 ON w2.animal_id = dates.animal_id AND w2.date = dates.before_date
     WHERE (dates.latest_date - dates.before_date) > 0
-      AND animals.status = 'engorde'
+      AND animals.status = 'engorde'${ranchClause}
     GROUP BY animals.species
-  `);
+  `,
+    ...params,
+  );
 
   // Días desde el ingreso (promedio) por especie.
   const daysInRanch = await prisma.$queryRawUnsafe<
     { species: string; days_in_ranch: number }[]
-  >(`
+  >(
+    `
     SELECT animals.species AS species,
            AVG(w.days_in_ranch)::float8 AS days_in_ranch
     FROM animals
@@ -79,19 +93,27 @@ export async function getDashboardStats(): Promise<DashboardStats> {
       SELECT animal_id, date(NOW()) - MIN(weights.date) AS days_in_ranch
       FROM weights GROUP BY animal_id
     ) AS w ON w.animal_id = animals.id
-    WHERE animals.status = 'engorde'
+    WHERE animals.status = 'engorde'${ranchClause}
     GROUP BY animals.species
-  `);
+  `,
+    ...params,
+  );
 
   const bovineAvg = avgWeight.find((r) => r.species === "bovino");
   const bovineGain = dailyGain.find((r) => r.species === "bovino");
   const bovineDays = daysInRanch.find((r) => r.species === "bovino");
 
+  // Conteos de inventario, filtrados por la hacienda activa cuando aplica. Las
+  // ventas se asocian a una hacienda a través de los animales que incluyen.
+  const animalWhere = activeRanch ? { ranch: activeRanch } : undefined;
+  const saleWhere = activeRanch
+    ? { animals: { some: { ranch: activeRanch } } }
+    : undefined;
   const [totalAnimals, totalLots, totalPlots, totalSales] = await Promise.all([
-    prisma.animal.count(),
-    prisma.lot.count(),
-    prisma.plot.count(),
-    prisma.sale.count(),
+    prisma.animal.count({ where: animalWhere }),
+    prisma.lot.count({ where: animalWhere }),
+    prisma.plot.count({ where: animalWhere }),
+    prisma.sale.count({ where: saleWhere }),
   ]);
 
   return {
@@ -346,8 +368,12 @@ export type SaleStatRow = {
   daily_gain: number | null;
 };
 
-export async function getSaleStats(): Promise<SaleStatRow[]> {
-  const rows = await prisma.$queryRawUnsafe<SaleStatRow[]>(`
+export async function getSaleStats(ranch?: string): Promise<SaleStatRow[]> {
+  const activeRanch = ranch?.trim() || undefined;
+  const ranchClause = activeRanch ? ` WHERE animals.ranch = $1` : "";
+  const params: unknown[] = activeRanch ? [activeRanch] : [];
+  const rows = await prisma.$queryRawUnsafe<SaleStatRow[]>(
+    `
     SELECT
       sales.id AS sale_id,
       sales.date AS date,
@@ -370,10 +396,12 @@ export async function getSaleStats(): Promise<SaleStatRow[]> {
       FROM weights GROUP BY weights.animal_id
     ) AS dates ON dates.animal_id = animals.id
     JOIN weights latest_weight ON latest_weight.animal_id = animals.id AND dates.latest_date = latest_weight.date
-    JOIN weights first_weight ON first_weight.animal_id = animals.id AND dates.first_date = first_weight.date
+    JOIN weights first_weight ON first_weight.animal_id = animals.id AND dates.first_date = first_weight.date${ranchClause}
     GROUP BY sales.id
     ORDER BY sales.date DESC NULLS LAST
-  `);
+  `,
+    ...params,
+  );
   return rows.map((r) => ({
     ...r,
     animal_count: toNum(r.animal_count) ?? 0,


### PR DESCRIPTION
## Resumen

Agrega un selector de hacienda en la barra lateral y hace que la hacienda elegida filtre automáticamente toda la aplicación.

## Cambios

### Selector y administración
- Nuevo dropdown `HaciendaSwitcher` en la barra lateral (escritorio y móvil) para elegir la hacienda activa. La selección se guarda en una cookie legible por el servidor (`active_hacienda`), siguiendo el mismo patrón que el conmutador de unidad de peso.
- El menú incluye un acceso **Hacienda Admin** que lleva a `/haciendas`, donde se crean y configuran haciendas. Reemplaza la entrada de navegación "Haciendas".
- Helper de servidor `getActiveHacienda()` (`src/lib/activeHacienda.ts`).
- Iconos `ChevronDownIcon` y `CheckIcon`.

### Filtro global por hacienda activa
Cuando hay una hacienda seleccionada, se acotan a esa hacienda:
- **Animales**: `getLatestWeights` acepta `ranch` (combinado con la búsqueda por texto vía AND).
- **Lotes** y **potreros**: `where: { ranch }` en Prisma.
- **Dashboard**: `getDashboardStats(ranch?)` filtra las métricas de bovinos y los conteos de inventario; el mapa de potreros también se filtra.
- **Ventas**: lista y `getSaleStats(ranch?)` se filtran por los animales de la hacienda.
- **Pesos**: `where: { animal: { ranch } }`.

Cada encabezado indica la hacienda activa. Con "Todas las haciendas" el comportamiento es global, como antes. Toda la parametrización SQL usa placeholders (`$1`).

## Verificación
- `npx tsc --noEmit` pasa sin errores.

https://claude.ai/code/session_01HXDd9P4ut4zKuRZ5KGecJU

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXDd9P4ut4zKuRZ5KGecJU)_