### PR TITLE
Gestión de usuarios con roles administrador y lector

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ de forma nativa en **Vercel**, con una interfaz **moderna y mobile-first**.
 ```
 prisma/schema.prisma      Esquema (tablas/columnas snake_case heredadas de Rails)
 src/lib/queries.ts        Consultas SQL crudas: GDP, ROI, stats de lotes y potreros
-src/lib/auth.ts           Sesiones, roles (admin/editor) y verificación bcrypt
+src/lib/auth.ts           Sesiones, roles (admin/lector) y verificación bcrypt
 src/actions/              Server Actions (CRUD) por entidad
 src/components/           UI mobile-first (AppShell, tarjetas, tablas, formularios)
 src/app/(app)/            Páginas protegidas (tablero + entidades)
@@ -99,11 +99,25 @@ navegación. Internamente los pesos se almacenan siempre en kilogramos; la
 conversión se aplica solo a la visualización y la captura. Los importes en
 dinero ($/kg, totales) no cambian con la unidad.
 
-## 🔐 Roles
+## 🔐 Roles y usuarios
 
-- **admin**: acceso total (incluye editar y eliminar).
-- **editor**: puede crear y actualizar registros.
-- **viewer** (cualquier usuario autenticado): solo lectura.
+La aplicación maneja **dos tipos de usuario**:
+
+- **Administrador** (`admin`): acceso total. Puede ver, crear, editar y eliminar
+  registros, y además **gestionar usuarios** (crear, editar y eliminar cuentas).
+- **Lector** (`viewer`): solo lectura. Ve toda la información de la aplicación
+  pero no puede crear, editar ni eliminar nada; los botones de acción se ocultan
+  automáticamente.
+
+Los administradores gestionan las cuentas desde **Usuarios** en el menú lateral
+(`/usuarios`), donde pueden dar de alta lectores u otros administradores y
+restablecer contraseñas. Por seguridad, siempre debe existir al menos un
+administrador (no es posible eliminar ni degradar el último) y nadie puede
+eliminar su propia cuenta.
+
+> Nota: el rol histórico `editor` (crear/editar sin eliminar) heredado de la app
+> original sigue siendo válido a nivel de permisos, pero la gestión de usuarios
+> solo ofrece **Administrador** y **Lector**.
 
 Las estadísticas de bovinos consideran únicamente animales con estatus
 `engorde`, calculadas a partir de sus dos pesos más recientes.

--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -1,0 +1,144 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import bcrypt from "bcryptjs";
+import { prisma } from "@/lib/db";
+import { requireAdmin, getCurrentUser, ROLES, type Role } from "@/lib/auth";
+import { str } from "@/actions/helpers";
+
+const MIN_PASSWORD_LENGTH = 6;
+
+function normalizeRole(value: string | null): Role {
+  return ROLES.includes(value as Role) ? (value as Role) : "viewer";
+}
+
+function userData(formData: FormData) {
+  return {
+    firstName: str(formData.get("first_name")),
+    lastName: str(formData.get("last_name")),
+    email: str(formData.get("email")),
+    password: str(formData.get("password")),
+    role: normalizeRole(str(formData.get("role"))),
+  };
+}
+
+export async function createUser(formData: FormData) {
+  await requireAdmin();
+  const data = userData(formData);
+
+  if (!data.email) {
+    redirect("/usuarios/new?error=El correo electrónico es obligatorio");
+  }
+  if (!data.password || data.password.length < MIN_PASSWORD_LENGTH) {
+    redirect(
+      `/usuarios/new?error=La contraseña debe tener al menos ${MIN_PASSWORD_LENGTH} caracteres`,
+    );
+  }
+  const existing = await prisma.user.findFirst({
+    where: { email: { equals: data.email, mode: "insensitive" } },
+  });
+  if (existing) {
+    redirect("/usuarios/new?error=Ya existe un usuario con ese correo");
+  }
+
+  const passwordDigest = await bcrypt.hash(data.password, 10);
+  const user = await prisma.user.create({
+    data: {
+      firstName: data.firstName,
+      lastName: data.lastName,
+      email: data.email,
+      role: data.role,
+      passwordDigest,
+    },
+  });
+  revalidatePath("/usuarios");
+  redirect(`/usuarios?notice=Usuario ${user.email} creado correctamente`);
+}
+
+export async function updateUser(id: number, formData: FormData) {
+  await requireAdmin();
+  const data = userData(formData);
+
+  const target = await prisma.user.findUnique({ where: { id } });
+  if (!target) {
+    redirect("/usuarios?error=El usuario ya no existe");
+  }
+
+  if (!data.email) {
+    redirect(`/usuarios/${id}/edit?error=El correo electrónico es obligatorio`);
+  }
+  const clash = await prisma.user.findFirst({
+    where: {
+      email: { equals: data.email, mode: "insensitive" },
+      NOT: { id },
+    },
+  });
+  if (clash) {
+    redirect(`/usuarios/${id}/edit?error=Ya existe otro usuario con ese correo`);
+  }
+
+  // No permitir degradar al último administrador (se quedaría sin gestión).
+  if (target!.role === "admin" && data.role !== "admin") {
+    const admins = await prisma.user.count({ where: { role: "admin" } });
+    if (admins <= 1) {
+      redirect(
+        `/usuarios/${id}/edit?error=Debe existir al menos un administrador`,
+      );
+    }
+  }
+
+  const updateData: {
+    firstName: string | null;
+    lastName: string | null;
+    email: string | null;
+    role: Role;
+    passwordDigest?: string;
+  } = {
+    firstName: data.firstName,
+    lastName: data.lastName,
+    email: data.email,
+    role: data.role,
+  };
+
+  // La contraseña solo se cambia si se proporcionó una nueva.
+  if (data.password) {
+    if (data.password.length < MIN_PASSWORD_LENGTH) {
+      redirect(
+        `/usuarios/${id}/edit?error=La contraseña debe tener al menos ${MIN_PASSWORD_LENGTH} caracteres`,
+      );
+    }
+    updateData.passwordDigest = await bcrypt.hash(data.password, 10);
+  }
+
+  await prisma.user.update({ where: { id }, data: updateData });
+  revalidatePath("/usuarios");
+  redirect(`/usuarios?notice=Usuario actualizado correctamente`);
+}
+
+export async function deleteUser(formData: FormData) {
+  const current = await requireAdmin();
+  const id = Number(formData.get("id"));
+
+  // Un administrador no puede eliminar su propia cuenta.
+  if (id === current.id) {
+    redirect("/usuarios?error=No puedes eliminar tu propio usuario");
+  }
+
+  const target = await prisma.user.findUnique({ where: { id } });
+  if (!target) {
+    redirect("/usuarios?error=El usuario ya no existe");
+  }
+
+  // No permitir eliminar al último administrador.
+  if (target!.role === "admin") {
+    const admins = await prisma.user.count({ where: { role: "admin" } });
+    if (admins <= 1) {
+      redirect("/usuarios?error=Debe existir al menos un administrador");
+    }
+  }
+
+  await prisma.user.delete({ where: { id } });
+  revalidatePath("/usuarios");
+  redirect("/usuarios?notice=Usuario eliminado");
+}

--- a/src/app/(app)/animals/page.tsx
+++ b/src/app/(app)/animals/page.tsx
@@ -5,6 +5,7 @@ import { CowIcon, SearchIcon, ChevronRightIcon } from "@/components/icons";
 import { fmtNumber } from "@/lib/utils";
 import { getWeightUnit, convertFromKg, fmtWeight } from "@/lib/units";
 import { getActiveHacienda } from "@/lib/activeHacienda";
+import { getCurrentUser, isEditor } from "@/lib/auth";
 
 export const dynamic = "force-dynamic";
 
@@ -31,10 +32,12 @@ export default async function AnimalsPage({
 }) {
   const sp = await searchParams;
   const page = Math.max(1, parseInt(sp.page ?? "1", 10) || 1);
-  const [unit, activeHacienda] = await Promise.all([
+  const [unit, activeHacienda, user] = await Promise.all([
     getWeightUnit(),
     getActiveHacienda(),
+    getCurrentUser(),
   ]);
+  const canEdit = isEditor(user?.role);
   const { rows, total } = await getLatestWeights({
     search: sp.search,
     ranch: activeHacienda ?? undefined,
@@ -67,7 +70,7 @@ export default async function AnimalsPage({
         subtitle={`${fmtNumber(total)} en engorde · pesos más recientes${
           activeHacienda ? ` · ${activeHacienda}` : ""
         }`}
-        action={{ href: "/animals/new", label: "Nuevo animal" }}
+        action={canEdit ? { href: "/animals/new", label: "Nuevo animal" } : undefined}
       />
 
       {/* Filtros */}
@@ -117,7 +120,7 @@ export default async function AnimalsPage({
           icon={<CowIcon width={26} height={26} />}
           title="Sin resultados"
           description="No hay animales en engorde que coincidan. Registra uno nuevo o ajusta la búsqueda."
-          action={{ href: "/animals/new", label: "Nuevo animal" }}
+          action={canEdit ? { href: "/animals/new", label: "Nuevo animal" } : undefined}
         />
       ) : (
         <>

--- a/src/app/(app)/haciendas/page.tsx
+++ b/src/app/(app)/haciendas/page.tsx
@@ -3,17 +3,20 @@ import { prisma } from "@/lib/db";
 import { PageHeader, EmptyState, Card, Badge } from "@/components/ui";
 import { LeafIcon, ChevronRightIcon } from "@/components/icons";
 import { fmtNumber } from "@/lib/utils";
+import { getCurrentUser, isEditor } from "@/lib/auth";
 
 export const dynamic = "force-dynamic";
 
 export default async function HaciendasPage() {
-  const [haciendas, animalsByRanch, lotsByRanch, plotsByRanch] =
+  const [haciendas, animalsByRanch, lotsByRanch, plotsByRanch, user] =
     await Promise.all([
       prisma.hacienda.findMany({ orderBy: { name: "asc" } }),
       prisma.animal.groupBy({ by: ["ranch"], _count: { _all: true } }),
       prisma.lot.groupBy({ by: ["ranch"], _count: { _all: true } }),
       prisma.plot.groupBy({ by: ["ranch"], _count: { _all: true } }),
+      getCurrentUser(),
     ]);
+  const canEdit = isEditor(user?.role);
 
   const countFor = (
     rows: { ranch: string | null; _count: { _all: number } }[],
@@ -25,7 +28,7 @@ export default async function HaciendasPage() {
       <PageHeader
         title="Haciendas"
         subtitle={`${fmtNumber(haciendas.length)} haciendas registradas`}
-        action={{ href: "/haciendas/new", label: "Nueva hacienda" }}
+        action={canEdit ? { href: "/haciendas/new", label: "Nueva hacienda" } : undefined}
       />
 
       {haciendas.length === 0 ? (
@@ -33,7 +36,7 @@ export default async function HaciendasPage() {
           icon={<LeafIcon width={26} height={26} />}
           title="Sin haciendas"
           description="Registra tu primera hacienda para poder seleccionarla en animales, lotes y potreros."
-          action={{ href: "/haciendas/new", label: "Nueva hacienda" }}
+          action={canEdit ? { href: "/haciendas/new", label: "Nueva hacienda" } : undefined}
         />
       ) : (
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">

--- a/src/app/(app)/lots/page.tsx
+++ b/src/app/(app)/lots/page.tsx
@@ -5,12 +5,13 @@ import { LotsIcon, ChevronRightIcon } from "@/components/icons";
 import { fmtNumber, fmtDate } from "@/lib/utils";
 import { getWeightUnit, fmtWeight } from "@/lib/units";
 import { getActiveHacienda } from "@/lib/activeHacienda";
+import { getCurrentUser, isEditor } from "@/lib/auth";
 
 export const dynamic = "force-dynamic";
 
 export default async function LotsPage() {
   const activeHacienda = await getActiveHacienda();
-  const [lots, unit] = await Promise.all([
+  const [lots, unit, user] = await Promise.all([
     prisma.lot.findMany({
       where: activeHacienda ? { ranch: activeHacienda } : undefined,
       orderBy: [{ ranch: "asc" }, { species: "asc" }, { number: "asc" }],
@@ -22,7 +23,9 @@ export default async function LotsPage() {
       },
     }),
     getWeightUnit(),
+    getCurrentUser(),
   ]);
+  const canEdit = isEditor(user?.role);
 
   return (
     <div>
@@ -31,7 +34,7 @@ export default async function LotsPage() {
         subtitle={`${fmtNumber(lots.length)} lotes registrados${
           activeHacienda ? ` · ${activeHacienda}` : ""
         }`}
-        action={{ href: "/lots/new", label: "Nuevo lote" }}
+        action={canEdit ? { href: "/lots/new", label: "Nuevo lote" } : undefined}
       />
 
       {lots.length === 0 ? (
@@ -39,7 +42,7 @@ export default async function LotsPage() {
           icon={<LotsIcon width={26} height={26} />}
           title="Sin lotes"
           description="Crea tu primer lote para agrupar y dar seguimiento a tus animales."
-          action={{ href: "/lots/new", label: "Nuevo lote" }}
+          action={canEdit ? { href: "/lots/new", label: "Nuevo lote" } : undefined}
         />
       ) : (
         <>

--- a/src/app/(app)/plot_evaluations/page.tsx
+++ b/src/app/(app)/plot_evaluations/page.tsx
@@ -3,21 +3,26 @@ import { prisma } from "@/lib/db";
 import { PageHeader, EmptyState, TableWrap, Th, Td } from "@/components/ui";
 import { CalendarIcon, ChevronRightIcon } from "@/components/icons";
 import { fmtNumber, fmtDate } from "@/lib/utils";
+import { getCurrentUser, isEditor } from "@/lib/auth";
 
 export const dynamic = "force-dynamic";
 
 export default async function PlotEvaluationsPage() {
-  const evaluations = await prisma.plotEvaluation.findMany({
-    orderBy: { date: "desc" },
-    include: { plot: true },
-  });
+  const [evaluations, user] = await Promise.all([
+    prisma.plotEvaluation.findMany({
+      orderBy: { date: "desc" },
+      include: { plot: true },
+    }),
+    getCurrentUser(),
+  ]);
+  const canEdit = isEditor(user?.role);
 
   return (
     <div>
       <PageHeader
         title="Evaluaciones de potrero"
         subtitle={`${fmtNumber(evaluations.length)} evaluaciones`}
-        action={{ href: "/plot_evaluations/new", label: "Nueva evaluación" }}
+        action={canEdit ? { href: "/plot_evaluations/new", label: "Nueva evaluación" } : undefined}
       />
 
       {evaluations.length === 0 ? (
@@ -25,7 +30,7 @@ export default async function PlotEvaluationsPage() {
           icon={<CalendarIcon width={26} height={26} />}
           title="Sin evaluaciones"
           description="Registra evaluaciones de agua, pasto y cercas de tus potreros."
-          action={{ href: "/plot_evaluations/new", label: "Nueva evaluación" }}
+          action={canEdit ? { href: "/plot_evaluations/new", label: "Nueva evaluación" } : undefined}
         />
       ) : (
         <TableWrap>

--- a/src/app/(app)/plots/page.tsx
+++ b/src/app/(app)/plots/page.tsx
@@ -5,6 +5,7 @@ import { EmptyState, TableWrap, Th, Td, Card, Badge } from "@/components/ui";
 import { PlotIcon, ChevronRightIcon, PlusIcon } from "@/components/icons";
 import { fmtNumber } from "@/lib/utils";
 import { getActiveHacienda } from "@/lib/activeHacienda";
+import { getCurrentUser, isEditor } from "@/lib/auth";
 
 export const dynamic = "force-dynamic";
 
@@ -17,14 +18,16 @@ function scoreColor(avg: number | null): "green" | "amber" | "red" | "slate" {
 
 export default async function PlotsPage() {
   const activeHacienda = await getActiveHacienda();
-  const [plots, scores] = await Promise.all([
+  const [plots, scores, user] = await Promise.all([
     prisma.plot.findMany({
       where: activeHacienda ? { ranch: activeHacienda } : undefined,
       orderBy: [{ ranch: "asc" }, { number: "asc" }],
       include: { _count: { select: { evaluations: true } } },
     }),
     getLatestPlotScores(),
+    getCurrentUser(),
   ]);
+  const canEdit = isEditor(user?.role);
   const scoreByPlot = new Map(scores.map((s) => [s.plot_id, s]));
 
   return (
@@ -39,22 +42,24 @@ export default async function PlotsPage() {
             {activeHacienda ? ` · ${activeHacienda}` : ""}
           </p>
         </div>
-        <div className="flex items-center gap-2">
-          <Link
-            href="/plots/import"
-            className="inline-flex items-center gap-1.5 rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 active:scale-[0.98]"
-          >
-            <PlotIcon width={18} height={18} />
-            Importar KMZ
-          </Link>
-          <Link
-            href="/plots/new"
-            className="inline-flex items-center gap-1.5 rounded-xl bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-700 active:scale-[0.98]"
-          >
-            <PlusIcon width={18} height={18} />
-            Nuevo potrero
-          </Link>
-        </div>
+        {canEdit && (
+          <div className="flex items-center gap-2">
+            <Link
+              href="/plots/import"
+              className="inline-flex items-center gap-1.5 rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 active:scale-[0.98]"
+            >
+              <PlotIcon width={18} height={18} />
+              Importar KMZ
+            </Link>
+            <Link
+              href="/plots/new"
+              className="inline-flex items-center gap-1.5 rounded-xl bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-700 active:scale-[0.98]"
+            >
+              <PlusIcon width={18} height={18} />
+              Nuevo potrero
+            </Link>
+          </div>
+        )}
       </div>
 
       {plots.length === 0 ? (
@@ -62,7 +67,7 @@ export default async function PlotsPage() {
           icon={<PlotIcon width={26} height={26} />}
           title="Sin potreros"
           description="Registra tus potreros para evaluar agua, pasto y cercas."
-          action={{ href: "/plots/new", label: "Nuevo potrero" }}
+          action={canEdit ? { href: "/plots/new", label: "Nuevo potrero" } : undefined}
         />
       ) : (
         <>

--- a/src/app/(app)/sales/page.tsx
+++ b/src/app/(app)/sales/page.tsx
@@ -6,6 +6,7 @@ import { MoneyIcon, ChevronRightIcon } from "@/components/icons";
 import { fmtNumber, fmtDate, fmtMoney, fmtPercent } from "@/lib/utils";
 import { getWeightUnit, fmtWeight } from "@/lib/units";
 import { getActiveHacienda } from "@/lib/activeHacienda";
+import { getCurrentUser, isEditor } from "@/lib/auth";
 
 export const dynamic = "force-dynamic";
 
@@ -16,7 +17,7 @@ function roiColor(roi: number | null): "green" | "red" | "slate" {
 
 export default async function SalesPage() {
   const activeHacienda = await getActiveHacienda();
-  const [sales, stats] = await Promise.all([
+  const [sales, stats, user] = await Promise.all([
     prisma.sale.findMany({
       where: activeHacienda
         ? { animals: { some: { ranch: activeHacienda } } }
@@ -25,7 +26,9 @@ export default async function SalesPage() {
       include: { _count: { select: { animals: true } } },
     }),
     getSaleStats(activeHacienda ?? undefined),
+    getCurrentUser(),
   ]);
+  const canEdit = isEditor(user?.role);
   const unit = await getWeightUnit();
   const statBySale = new Map(stats.map((s) => [s.sale_id, s]));
 
@@ -36,7 +39,7 @@ export default async function SalesPage() {
         subtitle={`${fmtNumber(sales.length)} ventas registradas${
           activeHacienda ? ` · ${activeHacienda}` : ""
         }`}
-        action={{ href: "/sales/new", label: "Nueva venta" }}
+        action={canEdit ? { href: "/sales/new", label: "Nueva venta" } : undefined}
       />
 
       {sales.length === 0 ? (
@@ -44,7 +47,7 @@ export default async function SalesPage() {
           icon={<MoneyIcon width={26} height={26} />}
           title="Sin ventas"
           description="Registra una venta y asígnale animales para calcular utilidad y ROI."
-          action={{ href: "/sales/new", label: "Nueva venta" }}
+          action={canEdit ? { href: "/sales/new", label: "Nueva venta" } : undefined}
         />
       ) : (
         <>

--- a/src/app/(app)/usuarios/[id]/edit/page.tsx
+++ b/src/app/(app)/usuarios/[id]/edit/page.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { prisma } from "@/lib/db";
+import { requireAdmin } from "@/lib/auth";
+import { updateUser } from "@/actions/users";
+import { UserForm } from "@/components/entity-forms/UserForm";
+import { ArrowLeftIcon } from "@/components/icons";
+
+export const dynamic = "force-dynamic";
+
+export default async function EditUserPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ error?: string }>;
+}) {
+  await requireAdmin();
+  const { id } = await params;
+  const { error } = await searchParams;
+  const userId = Number(id);
+  if (Number.isNaN(userId)) notFound();
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user) notFound();
+
+  return (
+    <div>
+      <Link
+        href="/usuarios"
+        className="mb-4 inline-flex items-center gap-1 text-sm font-medium text-slate-500 hover:text-slate-800"
+      >
+        <ArrowLeftIcon width={16} height={16} /> Usuarios
+      </Link>
+      <h1 className="mb-5 text-2xl font-bold tracking-tight text-slate-900">
+        Editar usuario
+      </h1>
+      <UserForm
+        action={updateUser.bind(null, user.id)}
+        user={user}
+        error={error}
+        submitLabel="Guardar cambios"
+      />
+    </div>
+  );
+}

--- a/src/app/(app)/usuarios/new/page.tsx
+++ b/src/app/(app)/usuarios/new/page.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import { requireAdmin } from "@/lib/auth";
+import { createUser } from "@/actions/users";
+import { UserForm } from "@/components/entity-forms/UserForm";
+import { ArrowLeftIcon } from "@/components/icons";
+
+export const dynamic = "force-dynamic";
+
+export default async function NewUserPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string }>;
+}) {
+  await requireAdmin();
+  const { error } = await searchParams;
+  return (
+    <div>
+      <Link
+        href="/usuarios"
+        className="mb-4 inline-flex items-center gap-1 text-sm font-medium text-slate-500 hover:text-slate-800"
+      >
+        <ArrowLeftIcon width={16} height={16} /> Usuarios
+      </Link>
+      <h1 className="mb-5 text-2xl font-bold tracking-tight text-slate-900">
+        Nuevo usuario
+      </h1>
+      <UserForm action={createUser} error={error} submitLabel="Crear usuario" />
+    </div>
+  );
+}

--- a/src/app/(app)/usuarios/page.tsx
+++ b/src/app/(app)/usuarios/page.tsx
@@ -1,0 +1,97 @@
+import Link from "next/link";
+import { prisma } from "@/lib/db";
+import { requireAdmin, roleLabel } from "@/lib/auth";
+import { deleteUser } from "@/actions/users";
+import {
+  PageHeader,
+  EmptyState,
+  TableWrap,
+  Th,
+  Td,
+  Badge,
+} from "@/components/ui";
+import { DeleteButton } from "@/components/DeleteButton";
+import { UsersIcon, EditIcon } from "@/components/icons";
+import { fmtNumber } from "@/lib/utils";
+
+export const dynamic = "force-dynamic";
+
+export default async function UsersPage() {
+  const current = await requireAdmin();
+  const users = await prisma.user.findMany({
+    orderBy: [{ role: "asc" }, { email: "asc" }],
+  });
+
+  return (
+    <div>
+      <PageHeader
+        title="Usuarios"
+        subtitle={`${fmtNumber(users.length)} usuarios · administradores y lectores`}
+        action={{ href: "/usuarios/new", label: "Nuevo usuario" }}
+      />
+
+      {users.length === 0 ? (
+        <EmptyState
+          icon={<UsersIcon width={26} height={26} />}
+          title="Sin usuarios"
+          description="Crea el primer usuario para dar acceso a la aplicación."
+          action={{ href: "/usuarios/new", label: "Nuevo usuario" }}
+        />
+      ) : (
+        <TableWrap>
+          <thead>
+            <tr>
+              <Th>Nombre</Th>
+              <Th>Correo</Th>
+              <Th>Rol</Th>
+              <Th></Th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map((u) => {
+              const name = [u.firstName, u.lastName]
+                .filter(Boolean)
+                .join(" ");
+              const isSelf = u.id === current.id;
+              return (
+                <tr key={u.id} className="transition hover:bg-slate-50">
+                  <Td className="font-semibold text-slate-900">
+                    {name || "—"}
+                    {isSelf && (
+                      <span className="ml-2 text-xs font-normal text-slate-400">
+                        (tú)
+                      </span>
+                    )}
+                  </Td>
+                  <Td>{u.email ?? "—"}</Td>
+                  <Td>
+                    <Badge color={u.role === "admin" ? "green" : "slate"}>
+                      {roleLabel(u.role)}
+                    </Badge>
+                  </Td>
+                  <Td>
+                    <div className="flex items-center justify-end gap-2">
+                      <Link
+                        href={`/usuarios/${u.id}/edit`}
+                        className="inline-flex items-center gap-1.5 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50"
+                      >
+                        <EditIcon width={16} height={16} /> Editar
+                      </Link>
+                      {!isSelf && (
+                        <DeleteButton
+                          action={deleteUser}
+                          id={u.id}
+                          confirmText={`¿Eliminar al usuario ${u.email}? Esta acción no se puede deshacer.`}
+                        />
+                      )}
+                    </div>
+                  </Td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </TableWrap>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/weights/page.tsx
+++ b/src/app/(app)/weights/page.tsx
@@ -6,15 +6,18 @@ import { fmtDate } from "@/lib/utils";
 import { getWeightUnit, fmtWeight } from "@/lib/units";
 import { getActiveHacienda } from "@/lib/activeHacienda";
 import { getActiveWeightMode } from "@/lib/activeWeightMode";
+import { getCurrentUser, isEditor } from "@/lib/auth";
 
 export const dynamic = "force-dynamic";
 
 export default async function WeightsPage() {
-  const [activeHacienda, mode, unit] = await Promise.all([
+  const [activeHacienda, mode, unit, user] = await Promise.all([
     getActiveHacienda(),
     getActiveWeightMode(),
     getWeightUnit(),
+    getCurrentUser(),
   ]);
+  const canEdit = isEditor(user?.role);
   const suffix = activeHacienda ? ` · ${activeHacienda}` : "";
 
   // Hacienda en modo "por lote": los pesos se registran a nivel de lote
@@ -32,7 +35,7 @@ export default async function WeightsPage() {
         <PageHeader
           title="Pesos"
           subtitle={`Pesados de lote más recientes${suffix}`}
-          action={{ href: "/lot_weighings/new", label: "Registrar pesado" }}
+          action={canEdit ? { href: "/lot_weighings/new", label: "Registrar pesado" } : undefined}
         />
 
         {weighings.length === 0 ? (
@@ -40,7 +43,7 @@ export default async function WeightsPage() {
             icon={<ScaleIcon width={26} height={26} />}
             title="Sin pesados"
             description="Registra el peso promedio de tus lotes para dar seguimiento a la GDP."
-            action={{ href: "/lot_weighings/new", label: "Registrar pesado" }}
+            action={canEdit ? { href: "/lot_weighings/new", label: "Registrar pesado" } : undefined}
           />
         ) : (
           <TableWrap>
@@ -102,7 +105,7 @@ export default async function WeightsPage() {
       <PageHeader
         title="Pesos"
         subtitle={`Últimos registros de peso${suffix}`}
-        action={{ href: "/weights/new", label: "Registrar peso" }}
+        action={canEdit ? { href: "/weights/new", label: "Registrar peso" } : undefined}
       />
 
       {weights.length === 0 ? (
@@ -110,7 +113,7 @@ export default async function WeightsPage() {
           icon={<ScaleIcon width={26} height={26} />}
           title="Sin pesos"
           description="Registra el peso de tus animales para dar seguimiento a la GDP."
-          action={{ href: "/weights/new", label: "Registrar peso" }}
+          action={canEdit ? { href: "/weights/new", label: "Registrar peso" } : undefined}
         />
       ) : (
         <TableWrap>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -19,11 +19,19 @@ import {
   LogoutIcon,
   LeafIcon,
   SidebarIcon,
+  UsersIcon,
 } from "@/components/icons";
 
 const SIDEBAR_STORAGE_KEY = "sidebar-collapsed";
 
-const NAV = [
+type NavItem = {
+  href: string;
+  label: string;
+  Icon: (props: { width?: number; height?: number }) => React.ReactNode;
+  exact?: boolean;
+};
+
+const NAV: NavItem[] = [
   { href: "/", label: "Tablero", Icon: DashboardIcon, exact: true },
   { href: "/animals", label: "Animales", Icon: CowIcon },
   { href: "/lots", label: "Lotes", Icon: LotsIcon },
@@ -58,10 +66,19 @@ export function AppShell({
 
   // En modo "por lote" los pesos se registran a nivel de lote, así que se oculta
   // la sección de Animales. La barra inferior móvil usa los 5 primeros destinos.
-  const nav = NAV.filter(
+  const baseNav = NAV.filter(
     (item) => !(item.href === "/animals" && activeWeightMode === "lot"),
   );
-  const mobileNav = nav.slice(0, 5);
+  // La gestión de usuarios solo es visible para administradores y se mantiene
+  // fuera de la barra inferior móvil (que se limita a 5 destinos).
+  const nav: NavItem[] =
+    user?.role === "admin"
+      ? [
+          ...baseNav,
+          { href: "/usuarios", label: "Usuarios", Icon: UsersIcon },
+        ]
+      : baseNav;
+  const mobileNav = baseNav.slice(0, 5);
 
   // Restaura la preferencia de la barra lateral guardada.
   useEffect(() => {

--- a/src/components/entity-forms/UserForm.tsx
+++ b/src/components/entity-forms/UserForm.tsx
@@ -1,0 +1,91 @@
+import Link from "next/link";
+import type { User } from "@prisma/client";
+import { Card } from "@/components/ui";
+import {
+  Field,
+  Input,
+  Select,
+  SubmitButton,
+  FormError,
+} from "@/components/forms";
+
+export function UserForm({
+  action,
+  user,
+  error,
+  submitLabel,
+}: {
+  action: (formData: FormData) => void | Promise<void>;
+  user?: User | null;
+  error?: string;
+  submitLabel: string;
+}) {
+  const isEdit = Boolean(user);
+  return (
+    <form action={action}>
+      <Card className="space-y-5 p-5 sm:p-6">
+        <FormError message={error} />
+        <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+          <Field label="Nombre" hint="Opcional">
+            <Input
+              name="first_name"
+              defaultValue={user?.firstName ?? ""}
+              placeholder="Ej. María"
+            />
+          </Field>
+          <Field label="Apellido" hint="Opcional">
+            <Input
+              name="last_name"
+              defaultValue={user?.lastName ?? ""}
+              placeholder="Ej. González"
+            />
+          </Field>
+        </div>
+        <Field label="Correo electrónico">
+          <Input
+            type="email"
+            name="email"
+            defaultValue={user?.email ?? ""}
+            placeholder="usuario@correo.com"
+            autoComplete="off"
+            required
+          />
+        </Field>
+        <Field
+          label={isEdit ? "Nueva contraseña" : "Contraseña"}
+          hint={
+            isEdit
+              ? "Déjala en blanco para conservar la contraseña actual"
+              : "Mínimo 6 caracteres"
+          }
+        >
+          <Input
+            type="password"
+            name="password"
+            autoComplete="new-password"
+            placeholder="••••••••"
+            required={!isEdit}
+          />
+        </Field>
+        <Field
+          label="Rol"
+          hint="El lector solo puede ver información; el administrador tiene acceso total."
+        >
+          <Select name="role" defaultValue={user?.role ?? "viewer"}>
+            <option value="viewer">Lector (solo lectura)</option>
+            <option value="admin">Administrador (acceso total)</option>
+          </Select>
+        </Field>
+        <div className="flex items-center gap-3 pt-1">
+          <SubmitButton>{submitLabel}</SubmitButton>
+          <Link
+            href="/usuarios"
+            className="rounded-xl px-4 py-2.5 text-sm font-semibold text-slate-600 hover:bg-slate-100"
+          >
+            Cancelar
+          </Link>
+        </div>
+      </Card>
+    </form>
+  );
+}

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -219,6 +219,16 @@ export function LeafIcon(p: IconProps) {
   );
 }
 
+export function UsersIcon(p: IconProps) {
+  return (
+    <svg {...base} {...p}>
+      <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+      <circle cx="9" cy="7" r="4" />
+      <path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
+    </svg>
+  );
+}
+
 export function SettingsIcon(p: IconProps) {
   return (
     <svg {...base} {...p}>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -26,6 +26,24 @@ export type SessionUser = {
   role: string;
 };
 
+// Roles soportados por la aplicación:
+//   - admin:  acceso total (ver, crear, editar y eliminar + gestión de usuarios).
+//   - viewer: solo lectura (el "lector"); ve toda la información pero no modifica.
+// El rol histórico "editor" (crear/editar pero no eliminar) sigue siendo válido
+// por compatibilidad, pero la interfaz de usuarios solo ofrece admin y viewer.
+export const ROLES = ["admin", "viewer"] as const;
+export type Role = (typeof ROLES)[number];
+
+export const ROLE_LABELS: Record<string, string> = {
+  admin: "Administrador",
+  editor: "Editor",
+  viewer: "Lector",
+};
+
+export function roleLabel(role: string | null | undefined): string {
+  return ROLE_LABELS[role ?? "viewer"] ?? "Lector";
+}
+
 export function isEditor(role: string | null | undefined): boolean {
   return role === "editor" || role === "admin";
 }


### PR DESCRIPTION
## Resumen

Configura el manejo de usuarios con **dos tipos de usuario**:

- **Administrador** (`admin`): acceso total — ver, crear, editar, eliminar y **gestionar usuarios**. Se mantiene el usuario actual sin cambios.
- **Lector** (`viewer`): ve toda la información pero no puede crear, editar ni eliminar nada.

## Cambios

### Gestión de usuarios (solo administradores)
- Nueva sección `/usuarios` con lista, alta (`/usuarios/new`) y edición (`/usuarios/[id]/edit`).
- Selección de rol (Administrador / Lector) y restablecimiento de contraseña.
- `src/actions/users.ts`: hash con bcrypt, validación de correo único y salvaguardas:
  - No se puede eliminar ni degradar al **último administrador**.
  - Nadie puede eliminar su **propia cuenta**.
- Enlace **"Usuarios"** en la barra lateral, visible solo para administradores.

### Interfaz coherente para el lector
- Se ocultan automáticamente los botones de **crear / registrar / importar** para lectores en todas las listas (animales, lotes, potreros, ventas, pesos, evaluaciones, haciendas), complementando los guardas de servidor ya existentes (`requireEditor` / `requireAdmin`).

### Otros
- Helpers de etiquetas de rol (`ROLES`, `roleLabel`) en `src/lib/auth.ts` y nuevo `UsersIcon`.
- README actualizado con la sección de roles y usuarios.

## Verificación
- `tsc --noEmit` ✅ sin errores
- `next build` ✅ build de producción exitoso; nuevas rutas `/usuarios`, `/usuarios/new`, `/usuarios/[id]/edit` registradas.

https://claude.ai/code/session_01N7XVfcVKcHVWz68xji8xAt

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7XVfcVKcHVWz68xji8xAt)_