### PR TITLE
Usar 'cabezas' en vez de 'animales' en el pesado por lotes

### DIFF
--- a/src/app/(app)/lots/[id]/page.tsx
+++ b/src/app/(app)/lots/[id]/page.tsx
@@ -138,7 +138,7 @@ export default async function LotShowPage({
                 value: fmtWeight(latest?.averageWeight ?? null, unit),
               },
               {
-                label: "Número de animales",
+                label: "Número de cabezas",
                 value:
                   latest?.animalCount != null ? (
                     <Badge color="green">{latest.animalCount}</Badge>
@@ -191,7 +191,7 @@ export default async function LotShowPage({
               <EmptyState
                 icon={<ScaleIcon width={24} height={24} />}
                 title="Sin pesados"
-                description="Registra el primer pesado del lote con su peso promedio y número de animales."
+                description="Registra el primer pesado del lote con su peso promedio y número de cabezas."
                 action={
                   canEdit
                     ? { href: `/lot_weighings/new?lot_id=${lot.id}`, label: "Nuevo pesado" }
@@ -207,7 +207,7 @@ export default async function LotShowPage({
                     {lot.weighings.length > 1 && (
                       <Th className="text-right">GDP</Th>
                     )}
-                    <Th className="text-right">Animales</Th>
+                    <Th className="text-right">Cabezas</Th>
                     <Th>Notas</Th>
                     {canEdit && <Th></Th>}
                   </tr>

--- a/src/app/(app)/lots/page.tsx
+++ b/src/app/(app)/lots/page.tsx
@@ -18,7 +18,7 @@ export default async function LotsPage() {
       include: {
         _count: { select: { animals: true } },
         plot: { select: { id: true, number: true } },
-        // Último pesado del lote: define el peso promedio y el número de animales.
+        // Último pesado del lote: define el peso promedio y el número de cabezas.
         weighings: { orderBy: [{ date: "desc" }, { id: "desc" }], take: 1 },
       },
     }),
@@ -58,7 +58,7 @@ export default async function LotsPage() {
                         {lot.name || `Lote ${lot.number}`}
                       </p>
                       <span className="text-xs text-slate-400">
-                        {latest?.animalCount ?? lot._count.animals} animales
+                        {latest?.animalCount ?? lot._count.animals} cabezas
                       </span>
                     </div>
                     <p className="text-xs text-slate-500">
@@ -97,7 +97,7 @@ export default async function LotsPage() {
                   <Th>Hacienda</Th>
                   <Th>Potrero</Th>
                   <Th>Especie</Th>
-                  <Th className="text-right">Animales</Th>
+                  <Th className="text-right">Cabezas</Th>
                   <Th className="text-right">Peso promedio</Th>
                   <Th className="text-right">Último pesado</Th>
                   <Th></Th>

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -49,7 +49,7 @@ export default async function DashboardPage() {
     }),
   ]);
 
-  // Marcadores del mapa: potreros con geometría + número de animales en cada uno.
+  // Marcadores del mapa: potreros con geometría + número de cabezas en cada uno.
   const plotMarkers: PlotMarker[] = plots
     .map((p) => {
       const ring = parseGeoJsonRing(p.boundaries);
@@ -161,7 +161,7 @@ export default async function DashboardPage() {
               Aún no hay potreros con geometría para mostrar en el mapa. Importa
               tus potreros desde un archivo KMZ en{" "}
               <span className="font-semibold text-slate-700">Potreros</span> para
-              verlos aquí con el número de animales en cada uno.
+              verlos aquí con el número de cabezas en cada uno.
             </p>
           </Card>
         ) : (

--- a/src/app/(app)/plots/[id]/page.tsx
+++ b/src/app/(app)/plots/[id]/page.tsx
@@ -46,7 +46,7 @@ export default async function PlotShowPage({
   const canDelete = isAdmin(user?.role);
   const ring = parseGeoJsonRing(plot.boundaries);
 
-  // Animales en el potrero: suma del número de animales de los lotes ubicados aquí.
+  // Cabezas en el potrero: suma del número de cabezas de los lotes ubicados aquí.
   const animalCount = plot.lots.reduce((sum, lot) => sum + lotHeadcount(lot), 0);
 
   const details = [
@@ -57,7 +57,7 @@ export default async function PlotShowPage({
       value: <span className="capitalize">{plot.plotType ?? "—"}</span>,
     },
     {
-      label: "Animales",
+      label: "Cabezas",
       value: <Badge color="green">{fmtNumber(animalCount)}</Badge>,
     },
     { label: "Área", value: plot.area ? `${fmtNumber(plot.area, 2)} ha` : "—" },

--- a/src/components/PlotsOverviewMap.tsx
+++ b/src/components/PlotsOverviewMap.tsx
@@ -12,7 +12,7 @@ export type PlotMarker = {
 };
 
 // Mapa satelital con TODOS los potreros dibujados y, en el centro de cada uno,
-// un círculo con el número de animales que hay en ese potrero. Leaflet se carga
+// un círculo con el número de cabezas que hay en ese potrero. Leaflet se carga
 // de forma diferida (solo en el cliente) para evitar acceder a `window` en SSR.
 export function PlotsOverviewMap({ plots }: { plots: PlotMarker[] }) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -64,9 +64,9 @@ export function PlotsOverviewMap({ plots }: { plots: PlotMarker[] }) {
         const pBounds = polygon.getBounds();
         bounds.extend(pBounds);
 
-        // Círculo con el número de animales en el centro del potrero.
-        // Solo se muestra cuando el potrero tiene animales; los potreros
-        // con cero animales no llevan círculo.
+        // Círculo con el número de cabezas en el centro del potrero.
+        // Solo se muestra cuando el potrero tiene cabezas; los potreros
+        // con cero cabezas no llevan círculo.
         if (p.animalCount <= 0) continue;
         const icon = L.divIcon({
           className: "plot-count-marker",
@@ -76,7 +76,7 @@ export function PlotsOverviewMap({ plots }: { plots: PlotMarker[] }) {
         });
         L.marker(pBounds.getCenter(), { icon })
           .addTo(map!)
-          .bindPopup(`<b>${p.label}</b><br/>${p.animalCount} animales`);
+          .bindPopup(`<b>${p.label}</b><br/>${p.animalCount} cabezas`);
       }
 
       if (bounds.isValid()) map.fitBounds(bounds, { padding: [30, 30] });

--- a/src/components/entity-forms/LotWeighingForm.tsx
+++ b/src/components/entity-forms/LotWeighingForm.tsx
@@ -64,7 +64,7 @@ export function LotWeighingForm({
             />
           </Field>
         </div>
-        <Field label="Número de animales">
+        <Field label="Número de cabezas">
           <Input
             type="number"
             step="1"

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -159,7 +159,7 @@ async function getBovineStatsByAnimal(ranch?: string): Promise<BovineStats> {
 }
 
 // Métricas de bovinos calculadas a partir de la información del lote (modelo
-// LotWeighing). Se usan en modo "Por Lote": el número de animales sale del
+// LotWeighing). Se usan en modo "Por Lote": el número de cabezas sale del
 // conteo del último pesado de cada lote y el peso/GDP se calculan por lote (no
 // por animal), ponderando el peso promedio por las cabezas de cada lote.
 async function getBovineStatsByLot(ranch?: string): Promise<BovineStats> {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -64,7 +64,7 @@ export function classNames(...classes: (string | false | null | undefined)[]) {
   return classes.filter(Boolean).join(" ");
 }
 
-// Número de animales de un lote: se toma del último pesado (animalCount); si el
+// Número de cabezas de un lote: se toma del último pesado (animalCount); si el
 // lote aún no tiene pesados, se usa el conteo de animales registrados.
 export function lotHeadcount(lot: {
   weighings: { animalCount: number | null }[];


### PR DESCRIPTION
Los términos 'cabezas' y 'animales' resultaban confusos. En el sistema
de pesado por lotes (modelo LotWeighing / modo 'Por Lote') el conteo
representa cabezas de ganado, no registros individuales de animales.

Se reemplaza 'animales' por 'cabezas' en todas las etiquetas visibles
que muestran ese conteo (formulario de pesado, lista y ficha de lotes,
ficha de potrero, popup y descripción del mapa). Se conservan las
referencias a registros de animales individuales (modo 'Por Animal':
animales del lote, ventas, haciendas).