### PR TITLE
Usar cabeza de toro como icono de la hacienda

### DIFF
--- a/src/app/(app)/haciendas/page.tsx
+++ b/src/app/(app)/haciendas/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { prisma } from "@/lib/db";
 import { PageHeader, EmptyState, Card, Badge } from "@/components/ui";
-import { LeafIcon, ChevronRightIcon } from "@/components/icons";
+import { BullHeadIcon, ChevronRightIcon } from "@/components/icons";
 import { fmtNumber } from "@/lib/utils";
 import { getCurrentUser, isEditor } from "@/lib/auth";
 
@@ -33,7 +33,7 @@ export default async function HaciendasPage() {
 
       {haciendas.length === 0 ? (
         <EmptyState
-          icon={<LeafIcon width={26} height={26} />}
+          icon={<BullHeadIcon width={26} height={26} />}
           title="Sin haciendas"
           description="Registra tu primera hacienda para poder seleccionarla en animales, lotes y potreros."
           action={canEdit ? { href: "/haciendas/new", label: "Nueva hacienda" } : undefined}
@@ -47,7 +47,7 @@ export default async function HaciendasPage() {
                   <div className="min-w-0">
                     <p className="flex items-center gap-2 text-lg font-bold text-slate-900">
                       <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-brand-50 text-brand-600">
-                        <LeafIcon width={18} height={18} />
+                        <BullHeadIcon width={18} height={18} />
                       </span>
                       {h.name}
                     </p>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
 import { getCurrentUser } from "@/lib/auth";
 import { Field, Input, FormError } from "@/components/forms";
-import { LeafIcon } from "@/components/icons";
+import { BullHeadIcon } from "@/components/icons";
 
 export default async function LoginPage({
   searchParams,
@@ -17,7 +17,7 @@ export default async function LoginPage({
       <div className="w-full max-w-sm">
         <div className="mb-8 flex flex-col items-center text-center">
           <span className="mb-3 flex h-14 w-14 items-center justify-center rounded-2xl bg-brand-600 text-white shadow-lg shadow-brand-600/30">
-            <LeafIcon width={28} height={28} />
+            <BullHeadIcon width={28} height={28} />
           </span>
           <h1 className="text-2xl font-bold tracking-tight text-slate-900">
             Haciendas

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -17,7 +17,7 @@ import {
   MenuIcon,
   CloseIcon,
   LogoutIcon,
-  LeafIcon,
+  BullHeadIcon,
   SidebarIcon,
   UsersIcon,
 } from "@/components/icons";
@@ -214,7 +214,7 @@ export function AppShell({
           <MenuIcon />
         </button>
         <Link href="/" className="flex items-center gap-2">
-          <LeafIcon className="text-brand-600" width={22} height={22} />
+          <BullHeadIcon className="text-brand-600" width={22} height={22} />
           <span className="text-lg font-bold text-slate-900">Haciendas</span>
         </Link>
         <div className="ml-auto">
@@ -262,7 +262,7 @@ function Brand() {
       className="flex items-center gap-2.5 px-5 py-4"
     >
       <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-brand-600 text-white">
-        <LeafIcon width={20} height={20} />
+        <BullHeadIcon width={20} height={20} />
       </span>
       <span className="text-lg font-bold tracking-tight text-slate-900">
         Haciendas

--- a/src/components/HaciendaSwitcher.tsx
+++ b/src/components/HaciendaSwitcher.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import { classNames } from "@/lib/utils";
 import { ACTIVE_HACIENDA_COOKIE } from "@/lib/activeHaciendaCookie";
 import {
-  LeafIcon,
+  BullHeadIcon,
   ChevronDownIcon,
   CheckIcon,
   SettingsIcon,
@@ -73,7 +73,7 @@ export function HaciendaSwitcher({
         aria-expanded={open}
       >
         <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-brand-50 text-brand-600">
-          <LeafIcon width={18} height={18} />
+          <BullHeadIcon width={18} height={18} />
         </span>
         <span className="min-w-0 flex-1">
           <span className="block text-[11px] font-medium uppercase tracking-wide text-slate-400">

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -210,11 +210,19 @@ export function SearchIcon(p: IconProps) {
   );
 }
 
-export function LeafIcon(p: IconProps) {
+export function BullHeadIcon(p: IconProps) {
   return (
     <svg {...base} {...p}>
-      <path d="M11 20A7 7 0 0 1 9.8 6.1C15.5 5 17 4.48 19 2c1 2 2 4.18 2 8a7 7 0 0 1-11 9.8" />
-      <path d="M2 21c0-3 1.85-5.36 5.08-6" />
+      {/* Cuernos */}
+      <path d="M6.5 7.5C4 6.8 2.4 4.8 2.8 2.3" />
+      <path d="M17.5 7.5c2.5-.7 4.1-2.7 3.7-5.2" />
+      {/* Cabeza */}
+      <path d="M6 7C8 5.5 16 5.5 18 7c.6 2.5 0 4.5-1.5 6.5C15 15.7 13.6 17 12 17s-3-1.3-4.5-3.5C6 11.5 5.4 9.5 6 7Z" />
+      {/* Ojos */}
+      <path d="M9.5 10h.01M14.5 10h.01" />
+      {/* Hocico */}
+      <path d="M11 13h.01M13 13h.01" />
+      <path d="M9.5 14.5c.7.5 1.6.8 2.5.8s1.8-.3 2.5-.8" />
     </svg>
   );
 }


### PR DESCRIPTION
## Resumen

Reemplaza el icono de hoja (`LeafIcon`) por un nuevo `BullHeadIcon` (cabeza de toro) como marca de la hacienda/app, acorde a una aplicación de gestión ganadera.

## Cambios

- **Nuevo `BullHeadIcon`** en `src/components/icons.tsx` — SVG de línea (mismo estilo `stroke` 24×24 que el resto de iconos): cuernos, contorno de la cabeza, ojos y hocico con fosas nasales.
- **Sustitución de `LeafIcon`** en todos los puntos donde funcionaba como marca:
  - `HaciendaSwitcher.tsx` — selector de hacienda activa en la barra lateral
  - `AppShell.tsx` — logo de la barra lateral y topbar móvil
  - `login/page.tsx` — insignia de la pantalla de inicio de sesión
  - `haciendas/page.tsx` — listado de haciendas y estado vacío
- **Eliminado `LeafIcon`** por quedar sin uso.

## Notas

Cambio puramente visual (intercambio de componente JSX), sin tocar lógica.

https://claude.ai/code/session_01JxehnYjfD98FcoaZLSYWcA

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxehnYjfD98FcoaZLSYWcA)_