### PR TITLE
Eliminar 'Animales' restante del modo Por Lote

### DIFF
--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -49,6 +49,10 @@ export default async function DashboardPage() {
     }),
   ]);
 
+  // En modo "Por Lote" la pantalla de animales individuales se oculta, así que
+  // las métricas de bovinos enlazan a los lotes en su lugar.
+  const bovineHref = weightMode === "lot" ? "/lots" : "/animals";
+
   // Marcadores del mapa: potreros con geometría + número de cabezas en cada uno.
   const plotMarkers: PlotMarker[] = plots
     .map((p) => {
@@ -89,7 +93,7 @@ export default async function DashboardPage() {
             label="Cabezas"
             value={fmtNumber(stats.bovineCount)}
             icon={<CowIcon width={22} height={22} />}
-            href="/animals"
+            href={bovineHref}
             accent="brand"
           />
           <StatCard
@@ -97,7 +101,7 @@ export default async function DashboardPage() {
             value={fmtNumber(convertFromKg(stats.bovineAverageWeight, unit), 1)}
             unit={weightLabel(unit)}
             icon={<ScaleIcon width={22} height={22} />}
-            href="/animals"
+            href={bovineHref}
             accent="blue"
           />
           <StatCard
@@ -105,7 +109,7 @@ export default async function DashboardPage() {
             value={fmtNumber(stats.bovineDaysInRanch)}
             unit="días"
             icon={<CalendarIcon width={22} height={22} />}
-            href="/animals"
+            href={bovineHref}
             accent="amber"
           />
           <StatCard
@@ -113,7 +117,7 @@ export default async function DashboardPage() {
             value={fmtNumber(convertFromKg(stats.bovineDailyGain, unit), 2)}
             unit={gainLabel(unit)}
             icon={<TrendUpIcon width={22} height={22} />}
-            href="/animals"
+            href={bovineHref}
             accent="violet"
           />
         </div>

--- a/src/app/(app)/weights/page.tsx
+++ b/src/app/(app)/weights/page.tsx
@@ -52,7 +52,7 @@ export default async function WeightsPage() {
                 <Th>Fecha</Th>
                 <Th>Lote</Th>
                 <Th className="text-right">Peso promedio</Th>
-                <Th className="text-right">Animales</Th>
+                <Th className="text-right">Cabezas</Th>
                 <Th>Nota</Th>
                 <Th></Th>
               </tr>


### PR DESCRIPTION
## Contexto

El menú lateral/inferior **ya ocultaba** la opción "Animales" en modo "Por Lote" (PR #37). Quedaban dos lugares donde el término aún aparecía en ese modo:

## Cambios

1. **Pesos** (`/weights` en modo por lote): la columna **"Animales"** de la tabla de pesados de lote pasa a **"Cabezas"**, consistente con el resto de la terminología.
2. **Dashboard**: las tarjetas de "Bovinos en engorde" enlazaban a `/animals`. Como esa pantalla está oculta en modo por lote, ahora enlazan a `/lots` en ese modo, evitando que el usuario llegue a la lista de animales individuales.

En modo "Por Animal" (o vista global) todo se mantiene igual.

https://claude.ai/code/session_01VNq8v1cwSVRguJAwp3bGoV

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNq8v1cwSVRguJAwp3bGoV)_