### PR TITLE
Ventas y estado del lote en modo Por Lote

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,24 @@ navegación. Internamente los pesos se almacenan siempre en kilogramos; la
 conversión se aplica solo a la visualización y la captura. Los importes en
 dinero ($/kg, totales) no cambian con la unidad.
 
+## 🏷️ Estado y venta del lote (modo Por Lote)
+
+En las haciendas configuradas **Por Lote**, cada lote tiene un **estado**:
+
+- **En crecimiento** (`growing`): el lote sigue en engorde. Es el estado por
+  defecto y el único que cuenta como **inventario activo** en las métricas de
+  bovinos del tablero y en el número de cabezas del mapa de potreros.
+- **Vendido** (`sold`): al marcar el lote como vendido se capturan los **datos de
+  la venta** (fecha, comprador, precio por kg y comentario). El total de la venta
+  se calcula con el peso total del último pesado (peso promedio × cabezas) por el
+  precio por kg.
+- **Destruido** (`destroyed`): el lote se dio de baja (muerte, decomiso u otra
+  pérdida) y deja el inventario activo.
+
+El estado se elige al crear o editar un lote y se muestra como etiqueta en la
+lista y en la ficha del lote. En modo Por Lote, la tarjeta **Ventas** del tablero
+cuenta los lotes vendidos.
+
 ## 🔐 Roles y usuarios
 
 La aplicación maneja **dos tipos de usuario**:

--- a/README.md
+++ b/README.md
@@ -114,8 +114,15 @@ En las haciendas configuradas **Por Lote**, cada lote tiene un **estado**:
   pérdida) y deja el inventario activo.
 
 El estado se elige al crear o editar un lote y se muestra como etiqueta en la
-lista y en la ficha del lote. En modo Por Lote, la tarjeta **Ventas** del tablero
-cuenta los lotes vendidos.
+lista y en la ficha del lote.
+
+En modo Por Lote la sección **Ventas** trabaja por lote (no por animales): lista
+los lotes vendidos y, desde **Vender lote**, permite **elegir un lote en
+crecimiento** y capturar la venta, lo que marca el lote como vendido. También se
+puede vender desde el botón **Vender lote** de la ficha del lote. La función de
+venta por animales (con ROI) solo aparece en haciendas configuradas Por Animal.
+El detalle de cada venta por lote vive en la ficha del lote, y la tarjeta
+**Ventas** del tablero cuenta los lotes vendidos.
 
 ## 🔐 Roles y usuarios
 

--- a/prisma/neon-lot-sales.sql
+++ b/prisma/neon-lot-sales.sql
@@ -1,0 +1,25 @@
+-- ============================================================================
+-- Migración incremental: estado y venta del lote (modo "Por Lote").
+-- Pega TODO este archivo en: Neon Dashboard -> SQL Editor -> Run
+-- (o aplica el esquema con `npm run db:push`).
+--
+-- Agrega a la tabla "lots":
+--   - status       -> estado del lote: "growing" (en crecimiento, por defecto),
+--                     "sold" (vendido) o "destroyed" (destruido).
+--   - sale_date    -> fecha de la venta (solo aplica cuando status = "sold").
+--   - buyer        -> comprador del lote.
+--   - sale_price   -> precio de venta por kilogramo.
+--   - sale_comment -> comentario de la venta.
+-- Es idempotente: se puede correr varias veces sin error.
+-- ============================================================================
+
+ALTER TABLE "lots"
+  ADD COLUMN IF NOT EXISTS "status" TEXT DEFAULT 'growing';
+
+-- Asegura que los lotes existentes queden "en crecimiento".
+UPDATE "lots" SET "status" = 'growing' WHERE "status" IS NULL;
+
+ALTER TABLE "lots" ADD COLUMN IF NOT EXISTS "sale_date" DATE;
+ALTER TABLE "lots" ADD COLUMN IF NOT EXISTS "buyer" TEXT;
+ALTER TABLE "lots" ADD COLUMN IF NOT EXISTS "sale_price" DOUBLE PRECISION;
+ALTER TABLE "lots" ADD COLUMN IF NOT EXISTS "sale_comment" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,6 +60,16 @@ model Lot {
   name        String?
   description String?
   plotId      Int?     @map("plot_id")
+  // Estado del lote en modo "Por Lote": "growing" (en crecimiento), "sold"
+  // (vendido) o "destroyed" (destruido). Solo los lotes en crecimiento cuentan
+  // como inventario activo en engorde.
+  status      String?  @default("growing")
+  // Datos de la venta del lote (solo aplican cuando status = "sold"). El precio
+  // de venta se guarda por kilogramo, igual que en las ventas por animal.
+  saleDate    DateTime? @db.Date  @map("sale_date")
+  buyer       String?
+  salePrice   Float?    @map("sale_price")
+  saleComment String?   @map("sale_comment")
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @default(now()) @updatedAt @map("updated_at")
 

--- a/src/actions/lots.ts
+++ b/src/actions/lots.ts
@@ -42,6 +42,30 @@ export async function updateLot(id: number, formData: FormData) {
   redirect(`/lots/${id}?notice=Lote actualizado correctamente`);
 }
 
+// Registra la venta de un lote desde la vista de Ventas (modo "Por Lote"):
+// marca el lote como vendido y guarda los datos de la venta.
+export async function sellLot(formData: FormData) {
+  await requireEditor();
+  const id = int(formData.get("lot_id"));
+  if (id === null) {
+    redirect("/sales/new?error=Selecciona un lote para vender");
+  }
+  await prisma.lot.update({
+    where: { id },
+    data: {
+      status: "sold",
+      saleDate: date(formData.get("sale_date")),
+      buyer: str(formData.get("buyer")),
+      salePrice: float(formData.get("sale_price")),
+      saleComment: str(formData.get("sale_comment")),
+    },
+  });
+  revalidatePath("/sales");
+  revalidatePath("/lots");
+  revalidatePath(`/lots/${id}`);
+  redirect("/sales?notice=Venta del lote registrada correctamente");
+}
+
 export async function deleteLot(formData: FormData) {
   await requireAdmin();
   const id = Number(formData.get("id"));

--- a/src/actions/lots.ts
+++ b/src/actions/lots.ts
@@ -4,9 +4,14 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/db";
 import { requireEditor, requireAdmin } from "@/lib/auth";
-import { str, int } from "@/actions/helpers";
+import { str, int, float, date } from "@/actions/helpers";
+import { normalizeLotStatus } from "@/lib/lotStatus";
 
 function lotData(formData: FormData) {
+  const status = normalizeLotStatus(str(formData.get("status")));
+  // Los datos de venta solo se guardan cuando el lote está vendido; al cambiar
+  // a otro estado se limpian para no dejar información obsoleta.
+  const sold = status === "sold";
   return {
     ranch: str(formData.get("ranch")),
     species: str(formData.get("species")),
@@ -14,6 +19,11 @@ function lotData(formData: FormData) {
     name: str(formData.get("name")),
     description: str(formData.get("description")),
     plotId: int(formData.get("plot_id")),
+    status,
+    saleDate: sold ? date(formData.get("sale_date")) : null,
+    buyer: sold ? str(formData.get("buyer")) : null,
+    salePrice: sold ? float(formData.get("sale_price")) : null,
+    saleComment: sold ? str(formData.get("sale_comment")) : null,
   };
 }
 

--- a/src/app/(app)/lots/[id]/page.tsx
+++ b/src/app/(app)/lots/[id]/page.tsx
@@ -12,7 +12,9 @@ import {
   CowIcon,
   PlusIcon,
   ScaleIcon,
+  MoneyIcon,
 } from "@/components/icons";
+import { getActiveWeightMode } from "@/lib/activeWeightMode";
 import { fmtNumber, fmtDate, fmtMoney } from "@/lib/utils";
 import {
   getWeightUnit,
@@ -62,7 +64,7 @@ export default async function LotShowPage({
   const lotId = Number(id);
   if (Number.isNaN(lotId)) notFound();
 
-  const [lot, user, unit] = await Promise.all([
+  const [lot, user, unit, weightMode] = await Promise.all([
     prisma.lot.findUnique({
       where: { id: lotId },
       include: {
@@ -73,11 +75,14 @@ export default async function LotShowPage({
     }),
     getCurrentUser(),
     getWeightUnit(),
+    getActiveWeightMode(),
   ]);
   if (!lot) notFound();
 
   const canEdit = isEditor(user?.role);
   const canDelete = isAdmin(user?.role);
+  // En modo "Por Lote", un lote en crecimiento se puede vender desde su ficha.
+  const canSell = canEdit && weightMode === "lot" && lot.status === "growing";
 
   // El peso promedio y el número de animales del lote provienen del último pesado.
   const latest = lot.weighings[0] ?? null;
@@ -110,6 +115,14 @@ export default async function LotShowPage({
           <ArrowLeftIcon width={16} height={16} /> Lotes
         </Link>
         <div className="flex items-center gap-2">
+          {canSell && (
+            <Link
+              href={`/sales/new?lot_id=${lot.id}`}
+              className="inline-flex items-center gap-1.5 rounded-xl bg-brand-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-700"
+            >
+              <MoneyIcon width={16} height={16} /> Vender lote
+            </Link>
+          )}
           {canEdit && (
             <Link
               href={`/lots/${lot.id}/edit`}

--- a/src/app/(app)/lots/[id]/page.tsx
+++ b/src/app/(app)/lots/[id]/page.tsx
@@ -13,7 +13,7 @@ import {
   PlusIcon,
   ScaleIcon,
 } from "@/components/icons";
-import { fmtNumber, fmtDate } from "@/lib/utils";
+import { fmtNumber, fmtDate, fmtMoney } from "@/lib/utils";
 import {
   getWeightUnit,
   fmtWeight,
@@ -21,6 +21,7 @@ import {
   gainLabel,
   type WeightUnit,
 } from "@/lib/units";
+import { lotStatusLabel, lotStatusBadgeColor } from "@/lib/lotStatus";
 
 export const dynamic = "force-dynamic";
 
@@ -88,6 +89,17 @@ export default async function LotShowPage({
   const overallGain =
     latest && oldest ? dailyGainKg(latest, oldest) : null;
 
+  // Total de la venta del lote: precio por kg × peso total del último pesado
+  // (peso promedio × número de cabezas). Solo aplica a lotes vendidos.
+  const saleWeightKg =
+    latest?.averageWeight != null && latest?.animalCount != null
+      ? latest.averageWeight * latest.animalCount
+      : null;
+  const saleTotal =
+    lot.salePrice != null && saleWeightKg != null
+      ? lot.salePrice * saleWeightKg
+      : null;
+
   return (
     <div>
       <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
@@ -110,15 +122,28 @@ export default async function LotShowPage({
         </div>
       </div>
 
-      <h1 className="mb-6 text-2xl font-bold tracking-tight text-slate-900">
-        {lot.name || `Lote ${lot.number}`}
-      </h1>
+      <div className="mb-6 flex flex-wrap items-center gap-3">
+        <h1 className="text-2xl font-bold tracking-tight text-slate-900">
+          {lot.name || `Lote ${lot.number}`}
+        </h1>
+        <Badge color={lotStatusBadgeColor(lot.status)}>
+          {lotStatusLabel(lot.status)}
+        </Badge>
+      </div>
 
       <div className="grid grid-cols-1 gap-5 lg:grid-cols-3">
         <Card className="lg:col-span-1">
           <DescList
             items={[
               { label: "Número", value: lot.number ?? "—" },
+              {
+                label: "Estado",
+                value: (
+                  <Badge color={lotStatusBadgeColor(lot.status)}>
+                    {lotStatusLabel(lot.status)}
+                  </Badge>
+                ),
+              },
               { label: "Hacienda", value: lot.ranch ?? "—" },
               {
                 label: "Potrero",
@@ -172,6 +197,35 @@ export default async function LotShowPage({
         </Card>
 
         <div className="lg:col-span-2 space-y-8">
+          {lot.status === "sold" && (
+            <div>
+              <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-400">
+                Venta del lote
+              </h2>
+              <Card>
+                <DescList
+                  items={[
+                    { label: "Comprador", value: lot.buyer ?? "—" },
+                    { label: "Fecha de venta", value: fmtDate(lot.saleDate) },
+                    {
+                      label: "Precio de venta",
+                      value:
+                        lot.salePrice != null
+                          ? `${fmtMoney(lot.salePrice)}/kg`
+                          : "—",
+                    },
+                    {
+                      label: "Peso total vendido",
+                      value: fmtWeight(saleWeightKg, unit, 0),
+                    },
+                    { label: "Total de la venta", value: fmtMoney(saleTotal) },
+                    { label: "Comentario", value: lot.saleComment ?? "—" },
+                  ]}
+                />
+              </Card>
+            </div>
+          )}
+
           <div>
             <div className="mb-3 flex items-center justify-between">
               <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-400">

--- a/src/app/(app)/lots/page.tsx
+++ b/src/app/(app)/lots/page.tsx
@@ -1,9 +1,10 @@
 import Link from "next/link";
 import { prisma } from "@/lib/db";
-import { PageHeader, EmptyState, TableWrap, Th, Td, Card } from "@/components/ui";
+import { PageHeader, EmptyState, TableWrap, Th, Td, Card, Badge } from "@/components/ui";
 import { LotsIcon, ChevronRightIcon } from "@/components/icons";
 import { fmtNumber, fmtDate } from "@/lib/utils";
 import { getWeightUnit, fmtWeight } from "@/lib/units";
+import { lotStatusLabel, lotStatusBadgeColor } from "@/lib/lotStatus";
 import { getActiveHacienda } from "@/lib/activeHacienda";
 import { getCurrentUser, isEditor } from "@/lib/auth";
 
@@ -53,14 +54,17 @@ export default async function LotsPage() {
               return (
                 <Link key={lot.id} href={`/lots/${lot.id}`}>
                   <Card className="p-4">
-                    <div className="flex items-center justify-between">
+                    <div className="flex items-center justify-between gap-2">
                       <p className="font-bold text-slate-900">
                         {lot.name || `Lote ${lot.number}`}
                       </p>
-                      <span className="text-xs text-slate-400">
-                        {latest?.animalCount ?? lot._count.animals} cabezas
-                      </span>
+                      <Badge color={lotStatusBadgeColor(lot.status)}>
+                        {lotStatusLabel(lot.status)}
+                      </Badge>
                     </div>
+                    <p className="mt-0.5 text-xs text-slate-400">
+                      {latest?.animalCount ?? lot._count.animals} cabezas
+                    </p>
                     <p className="text-xs text-slate-500">
                       {[
                         lot.ranch,
@@ -94,6 +98,7 @@ export default async function LotsPage() {
               <thead>
                 <tr>
                   <Th>Lote</Th>
+                  <Th>Estado</Th>
                   <Th>Hacienda</Th>
                   <Th>Potrero</Th>
                   <Th>Especie</Th>
@@ -110,6 +115,11 @@ export default async function LotsPage() {
                     <tr key={lot.id} className="hover:bg-slate-50">
                       <Td className="font-semibold text-slate-900">
                         {lot.name || lot.number || `#${lot.id}`}
+                      </Td>
+                      <Td>
+                        <Badge color={lotStatusBadgeColor(lot.status)}>
+                          {lotStatusLabel(lot.status)}
+                        </Badge>
                       </Td>
                       <Td>{lot.ranch ?? "—"}</Td>
                       <Td>

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -6,6 +6,7 @@ import { getActiveHacienda } from "@/lib/activeHacienda";
 import { getActiveWeightMode } from "@/lib/activeWeightMode";
 import { StatCard, Card } from "@/components/ui";
 import { fmtNumber, lotHeadcount } from "@/lib/utils";
+import { normalizeLotStatus } from "@/lib/lotStatus";
 import { parseGeoJsonRing } from "@/lib/kml";
 import { PlotsOverviewMap, type PlotMarker } from "@/components/PlotsOverviewMap";
 import {
@@ -37,6 +38,7 @@ export default async function DashboardPage() {
         boundaries: true,
         lots: {
           select: {
+            status: true,
             _count: { select: { animals: true } },
             weighings: {
               orderBy: [{ date: "desc" }, { id: "desc" }],
@@ -50,18 +52,20 @@ export default async function DashboardPage() {
   ]);
 
   // En modo "Por Lote" la pantalla de animales individuales se oculta, así que
-  // las métricas de bovinos enlazan a los lotes en su lugar.
+  // las métricas de bovinos enlazan a los lotes en su lugar. Las ventas también
+  // se gestionan desde los lotes (estado "vendido").
   const bovineHref = weightMode === "lot" ? "/lots" : "/animals";
+  const salesHref = weightMode === "lot" ? "/lots" : "/sales";
 
   // Marcadores del mapa: potreros con geometría + número de cabezas en cada uno.
+  // Los lotes vendidos o destruidos ya no aportan cabezas al inventario activo.
   const plotMarkers: PlotMarker[] = plots
     .map((p) => {
       const ring = parseGeoJsonRing(p.boundaries);
       if (!ring) return null;
-      const animalCount = p.lots.reduce(
-        (sum, lot) => sum + lotHeadcount(lot),
-        0,
-      );
+      const animalCount = p.lots
+        .filter((lot) => normalizeLotStatus(lot.status) === "growing")
+        .reduce((sum, lot) => sum + lotHeadcount(lot), 0);
       return {
         id: p.id,
         label: `Potrero ${p.number ?? p.id}`,
@@ -155,7 +159,7 @@ export default async function DashboardPage() {
             label="Ventas"
             value={fmtNumber(stats.totalSales)}
             icon={<MoneyIcon width={22} height={22} />}
-            href="/sales"
+            href={salesHref}
           />
         </div>
       </section>

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -52,10 +52,8 @@ export default async function DashboardPage() {
   ]);
 
   // En modo "Por Lote" la pantalla de animales individuales se oculta, así que
-  // las métricas de bovinos enlazan a los lotes en su lugar. Las ventas también
-  // se gestionan desde los lotes (estado "vendido").
+  // las métricas de bovinos enlazan a los lotes en su lugar.
   const bovineHref = weightMode === "lot" ? "/lots" : "/animals";
-  const salesHref = weightMode === "lot" ? "/lots" : "/sales";
 
   // Marcadores del mapa: potreros con geometría + número de cabezas en cada uno.
   // Los lotes vendidos o destruidos ya no aportan cabezas al inventario activo.
@@ -159,7 +157,7 @@ export default async function DashboardPage() {
             label="Ventas"
             value={fmtNumber(stats.totalSales)}
             icon={<MoneyIcon width={22} height={22} />}
-            href={salesHref}
+            href="/sales"
           />
         </div>
       </section>

--- a/src/app/(app)/sales/new/page.tsx
+++ b/src/app/(app)/sales/new/page.tsx
@@ -1,13 +1,73 @@
 import Link from "next/link";
+import { prisma } from "@/lib/db";
 import { requireEditor } from "@/lib/auth";
 import { createSale } from "@/actions/sales";
+import { sellLot } from "@/actions/lots";
 import { SaleForm } from "@/components/entity-forms/SaleForm";
+import { LotSaleForm } from "@/components/entity-forms/LotSaleForm";
 import { ArrowLeftIcon } from "@/components/icons";
+import { getActiveHacienda } from "@/lib/activeHacienda";
+import { getActiveWeightMode } from "@/lib/activeWeightMode";
 
 export const dynamic = "force-dynamic";
 
-export default async function NewSalePage() {
+export default async function NewSalePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ lot_id?: string }>;
+}) {
   await requireEditor();
+  const [mode, activeHacienda, sp] = await Promise.all([
+    getActiveWeightMode(),
+    getActiveHacienda(),
+    searchParams,
+  ]);
+
+  // En modo "Por Lote" la venta se hace eligiendo un lote en crecimiento; en
+  // modo "Por Animal" se mantiene el registro de venta basado en animales.
+  if (mode === "lot") {
+    const lots = await prisma.lot.findMany({
+      where: {
+        status: "growing",
+        ...(activeHacienda ? { ranch: activeHacienda } : {}),
+      },
+      orderBy: [{ ranch: "asc" }, { number: "asc" }],
+      select: { id: true, number: true, name: true, ranch: true },
+    });
+    const lotOptions = lots.map((l) => ({
+      id: l.id,
+      label:
+        [l.name || (l.number ? `Lote ${l.number}` : `#${l.id}`), l.ranch]
+          .filter(Boolean)
+          .join(" · "),
+    }));
+    const defaultLotId = sp.lot_id ? Number(sp.lot_id) : undefined;
+
+    return (
+      <div>
+        <Link
+          href="/sales"
+          className="mb-4 inline-flex items-center gap-1 text-sm font-medium text-slate-500 hover:text-slate-800"
+        >
+          <ArrowLeftIcon width={16} height={16} /> Ventas
+        </Link>
+        <h1 className="mb-5 text-2xl font-bold tracking-tight text-slate-900">
+          Vender lote
+        </h1>
+        <LotSaleForm
+          action={sellLot}
+          lots={lotOptions}
+          defaultLotId={
+            defaultLotId && lotOptions.some((l) => l.id === defaultLotId)
+              ? defaultLotId
+              : undefined
+          }
+          submitLabel="Registrar venta"
+        />
+      </div>
+    );
+  }
+
   return (
     <div>
       <Link

--- a/src/app/(app)/sales/page.tsx
+++ b/src/app/(app)/sales/page.tsx
@@ -6,6 +6,7 @@ import { MoneyIcon, ChevronRightIcon } from "@/components/icons";
 import { fmtNumber, fmtDate, fmtMoney, fmtPercent } from "@/lib/utils";
 import { getWeightUnit, fmtWeight } from "@/lib/units";
 import { getActiveHacienda } from "@/lib/activeHacienda";
+import { getActiveWeightMode } from "@/lib/activeWeightMode";
 import { getCurrentUser, isEditor } from "@/lib/auth";
 
 export const dynamic = "force-dynamic";
@@ -16,6 +17,155 @@ function roiColor(roi: number | null): "green" | "red" | "slate" {
 }
 
 export default async function SalesPage() {
+  // En modo "Por Lote" las ventas se gestionan por lote (estado "vendido"), no
+  // por animales individuales.
+  const mode = await getActiveWeightMode();
+  if (mode === "lot") return <LotSalesPage />;
+  return <AnimalSalesPage />;
+}
+
+// ---------------------------------------------------------------------------
+// Ventas por lote (modo "Por Lote"): lista de lotes vendidos. El detalle de
+// cada venta vive en la ficha del lote.
+// ---------------------------------------------------------------------------
+async function LotSalesPage() {
+  const activeHacienda = await getActiveHacienda();
+  const [lots, unit, user] = await Promise.all([
+    prisma.lot.findMany({
+      where: {
+        status: "sold",
+        ...(activeHacienda ? { ranch: activeHacienda } : {}),
+      },
+      orderBy: [{ saleDate: "desc" }, { id: "desc" }],
+      include: {
+        weighings: {
+          orderBy: [{ date: "desc" }, { id: "desc" }],
+          take: 1,
+          select: { averageWeight: true, animalCount: true },
+        },
+      },
+    }),
+    getWeightUnit(),
+    getCurrentUser(),
+  ]);
+  const canEdit = isEditor(user?.role);
+
+  // Peso total y total de la venta de cada lote, calculados con el último pesado.
+  const rows = lots.map((lot) => {
+    const latest = lot.weighings[0] ?? null;
+    const weightKg =
+      latest?.averageWeight != null && latest?.animalCount != null
+        ? latest.averageWeight * latest.animalCount
+        : null;
+    const total =
+      lot.salePrice != null && weightKg != null ? lot.salePrice * weightKg : null;
+    return { lot, headcount: latest?.animalCount ?? null, weightKg, total };
+  });
+
+  return (
+    <div>
+      <PageHeader
+        title="Ventas"
+        subtitle={`${fmtNumber(lots.length)} lotes vendidos${
+          activeHacienda ? ` · ${activeHacienda}` : ""
+        }`}
+        action={canEdit ? { href: "/sales/new", label: "Vender lote" } : undefined}
+      />
+
+      {lots.length === 0 ? (
+        <EmptyState
+          icon={<MoneyIcon width={26} height={26} />}
+          title="Sin ventas"
+          description="Registra una venta eligiendo un lote en crecimiento y sus datos de venta."
+          action={canEdit ? { href: "/sales/new", label: "Vender lote" } : undefined}
+        />
+      ) : (
+        <>
+          {/* Tarjetas móvil */}
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:hidden">
+            {rows.map(({ lot, headcount, total }) => (
+              <Link key={lot.id} href={`/lots/${lot.id}`}>
+                <Card className="p-4">
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="font-bold text-slate-900">
+                      {lot.name || `Lote ${lot.number}`}
+                    </p>
+                    <Badge color="blue">{fmtDate(lot.saleDate)}</Badge>
+                  </div>
+                  <p className="text-xs text-slate-500">
+                    {[lot.buyer, headcount != null ? `${headcount} cabezas` : null]
+                      .filter(Boolean)
+                      .join(" · ") || "—"}
+                  </p>
+                  <div className="mt-3 grid grid-cols-2 gap-2 text-center text-sm">
+                    <div className="rounded-lg bg-slate-50 py-1.5">
+                      <p className="text-xs text-slate-400">Precio/kg</p>
+                      <p className="font-semibold">
+                        {lot.salePrice != null ? fmtMoney(lot.salePrice) : "—"}
+                      </p>
+                    </div>
+                    <div className="rounded-lg bg-slate-50 py-1.5">
+                      <p className="text-xs text-slate-400">Total venta</p>
+                      <p className="font-semibold">{fmtMoney(total)}</p>
+                    </div>
+                  </div>
+                </Card>
+              </Link>
+            ))}
+          </div>
+
+          {/* Tabla escritorio */}
+          <div className="hidden lg:block">
+            <TableWrap>
+              <thead>
+                <tr>
+                  <Th>Lote</Th>
+                  <Th>Fecha de venta</Th>
+                  <Th>Comprador</Th>
+                  <Th className="text-right">Cabezas</Th>
+                  <Th className="text-right">Peso total</Th>
+                  <Th className="text-right">Precio/kg</Th>
+                  <Th className="text-right">Total venta</Th>
+                  <Th></Th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map(({ lot, headcount, weightKg, total }) => (
+                  <tr key={lot.id} className="hover:bg-slate-50">
+                    <Td className="font-semibold text-slate-900">
+                      {lot.name || lot.number || `#${lot.id}`}
+                    </Td>
+                    <Td>{fmtDate(lot.saleDate)}</Td>
+                    <Td>{lot.buyer ?? "—"}</Td>
+                    <Td className="text-right">{headcount ?? "—"}</Td>
+                    <Td className="text-right">{fmtWeight(weightKg, unit, 0)}</Td>
+                    <Td className="text-right">
+                      {lot.salePrice != null ? fmtMoney(lot.salePrice) : "—"}
+                    </Td>
+                    <Td className="text-right font-semibold">{fmtMoney(total)}</Td>
+                    <Td>
+                      <Link
+                        href={`/lots/${lot.id}`}
+                        className="inline-flex text-brand-600"
+                      >
+                        <ChevronRightIcon />
+                      </Link>
+                    </Td>
+                  </tr>
+                ))}
+              </tbody>
+            </TableWrap>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Ventas por animal (modo "Por Animal"): registros de venta con ROI.
+// ---------------------------------------------------------------------------
+async function AnimalSalesPage() {
   const activeHacienda = await getActiveHacienda();
   const [sales, stats, user] = await Promise.all([
     prisma.sale.findMany({

--- a/src/components/entity-forms/LotForm.tsx
+++ b/src/components/entity-forms/LotForm.tsx
@@ -3,6 +3,7 @@ import type { Lot, Plot } from "@prisma/client";
 import { Card } from "@/components/ui";
 import { Field, Input, Select, Textarea, SubmitButton } from "@/components/forms";
 import { RanchSelect } from "@/components/RanchSelect";
+import { LotStatusFields } from "@/components/entity-forms/LotStatusFields";
 
 const SPECIES = ["bovino", "ovino", "caprino", "equino", "porcino"];
 
@@ -56,6 +57,7 @@ export function LotForm({
         <Field label="Descripción">
           <Textarea name="description" defaultValue={lot?.description ?? ""} />
         </Field>
+        <LotStatusFields lot={lot} />
         <div className="flex items-center gap-3 pt-1">
           <SubmitButton>{submitLabel}</SubmitButton>
           <Link

--- a/src/components/entity-forms/LotSaleForm.tsx
+++ b/src/components/entity-forms/LotSaleForm.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link";
+import { Card } from "@/components/ui";
+import { Field, Input, Select, Textarea, SubmitButton } from "@/components/forms";
+
+// Formulario de venta en modo "Por Lote": se elige un lote disponible (en
+// crecimiento) y se capturan los datos de la venta. Al enviar, el lote queda
+// marcado como vendido.
+export function LotSaleForm({
+  action,
+  lots,
+  defaultLotId,
+  submitLabel,
+}: {
+  action: (formData: FormData) => void | Promise<void>;
+  lots: { id: number; label: string }[];
+  defaultLotId?: number;
+  submitLabel: string;
+}) {
+  return (
+    <form action={action}>
+      <Card className="space-y-5 p-5 sm:p-6">
+        <Field
+          label="Lote a vender"
+          hint="Solo se listan los lotes en crecimiento de la hacienda activa."
+        >
+          <Select name="lot_id" defaultValue={defaultLotId ?? ""} required>
+            <option value="" disabled>
+              — Selecciona un lote —
+            </option>
+            {lots.map((l) => (
+              <option key={l.id} value={l.id}>
+                {l.label}
+              </option>
+            ))}
+          </Select>
+        </Field>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <Field label="Fecha de venta">
+            <Input type="date" name="sale_date" />
+          </Field>
+          <Field label="Comprador">
+            <Input name="buyer" />
+          </Field>
+          <Field label="Precio de venta" hint="Por kilogramo">
+            <Input type="number" step="0.01" min="0" name="sale_price" />
+          </Field>
+        </div>
+
+        <Field label="Comentario de venta">
+          <Textarea name="sale_comment" />
+        </Field>
+
+        <div className="flex items-center gap-3 pt-1">
+          <SubmitButton>{submitLabel}</SubmitButton>
+          <Link
+            href="/sales"
+            className="rounded-xl px-4 py-2.5 text-sm font-semibold text-slate-600 hover:bg-slate-100"
+          >
+            Cancelar
+          </Link>
+        </div>
+      </Card>
+    </form>
+  );
+}

--- a/src/components/entity-forms/LotStatusFields.tsx
+++ b/src/components/entity-forms/LotStatusFields.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import type { Lot } from "@prisma/client";
+import { Field, Input, Select, Textarea } from "@/components/forms";
+import { toDateInput } from "@/lib/utils";
+import {
+  LOT_STATUSES,
+  normalizeLotStatus,
+  type LotStatus,
+} from "@/lib/lotStatus";
+
+// Selector de estado del lote (en crecimiento / vendido / destruido) y, cuando
+// el lote está "vendido", los datos de la venta. Es un componente cliente para
+// revelar la sección de venta solo al elegir el estado "Vendido".
+export function LotStatusFields({ lot }: { lot?: Lot | null }) {
+  const [status, setStatus] = useState<LotStatus>(
+    normalizeLotStatus(lot?.status),
+  );
+
+  return (
+    <div className="space-y-5">
+      <Field
+        label="Estado del lote"
+        hint="Solo los lotes en crecimiento cuentan como inventario activo en engorde."
+      >
+        <Select
+          name="status"
+          value={status}
+          onChange={(e) => setStatus(normalizeLotStatus(e.target.value))}
+        >
+          {LOT_STATUSES.map((s) => (
+            <option key={s.value} value={s.value}>
+              {s.label}
+            </option>
+          ))}
+        </Select>
+      </Field>
+
+      {status === "sold" && (
+        <div className="rounded-xl border border-blue-200 bg-blue-50/50 p-4 space-y-4">
+          <p className="text-sm font-semibold text-blue-900">Datos de la venta</p>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <Field label="Fecha de venta">
+              <Input
+                type="date"
+                name="sale_date"
+                defaultValue={toDateInput(lot?.saleDate)}
+              />
+            </Field>
+            <Field label="Comprador">
+              <Input name="buyer" defaultValue={lot?.buyer ?? ""} />
+            </Field>
+            <Field label="Precio de venta" hint="Por kilogramo">
+              <Input
+                type="number"
+                step="0.01"
+                min="0"
+                name="sale_price"
+                defaultValue={lot?.salePrice ?? ""}
+              />
+            </Field>
+          </div>
+          <Field label="Comentario de venta">
+            <Textarea
+              name="sale_comment"
+              defaultValue={lot?.saleComment ?? ""}
+            />
+          </Field>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/lotStatus.ts
+++ b/src/lib/lotStatus.ts
@@ -1,0 +1,61 @@
+// Estado de un lote en el modo de medición "Por Lote".
+//
+//   - "growing"   -> En crecimiento: el lote sigue en engorde. Cuenta como
+//                    inventario activo en las métricas de bovinos.
+//   - "sold"      -> Vendido: el lote se vendió. Se capturan los datos de la
+//                    venta (fecha, comprador, precio por kg y comentario).
+//   - "destroyed" -> Destruido: el lote se dio de baja (muerte, decomiso, etc.).
+//
+// El valor se guarda en la columna lots.status.
+
+export type LotStatus = "growing" | "sold" | "destroyed";
+
+export const DEFAULT_LOT_STATUS: LotStatus = "growing";
+
+export const LOT_STATUSES: {
+  value: LotStatus;
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: "growing",
+    label: "En crecimiento",
+    description: "El lote sigue en engorde y cuenta como inventario activo.",
+  },
+  {
+    value: "sold",
+    label: "Vendido",
+    description:
+      "El lote se vendió. Registra la fecha, el comprador y el precio de venta.",
+  },
+  {
+    value: "destroyed",
+    label: "Destruido",
+    description:
+      "El lote se dio de baja (muerte, decomiso u otra pérdida) y deja el inventario.",
+  },
+];
+
+export function normalizeLotStatus(
+  value: string | null | undefined,
+): LotStatus {
+  if (value === "sold" || value === "destroyed") return value;
+  return "growing";
+}
+
+export function lotStatusLabel(value: string | null | undefined): string {
+  return LOT_STATUSES.find((s) => s.value === normalizeLotStatus(value))!.label;
+}
+
+export function lotStatusBadgeColor(
+  value: string | null | undefined,
+): "green" | "blue" | "red" {
+  switch (normalizeLotStatus(value)) {
+    case "sold":
+      return "blue";
+    case "destroyed":
+      return "red";
+    default:
+      return "green";
+  }
+}

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -49,11 +49,19 @@ export async function getDashboardStats(
   const saleWhere = activeRanch
     ? { animals: { some: { ranch: activeRanch } } }
     : undefined;
+  // En modo "Por Lote" las ventas son lotes con estado "vendido"; en modo "Por
+  // Animal" son los registros de venta (tabla sales).
+  const salesPromise =
+    mode === "lot"
+      ? prisma.lot.count({
+          where: { ...(activeRanch ? { ranch: activeRanch } : {}), status: "sold" },
+        })
+      : prisma.sale.count({ where: saleWhere });
   const [totalAnimals, totalLots, totalPlots, totalSales] = await Promise.all([
     prisma.animal.count({ where: animalWhere }),
     prisma.lot.count({ where: animalWhere }),
     prisma.plot.count({ where: animalWhere }),
-    prisma.sale.count({ where: saleWhere }),
+    salesPromise,
   ]);
 
   return {
@@ -192,7 +200,8 @@ async function getBovineStatsByLot(ranch?: string): Promise<BovineStats> {
     JOIN (
       SELECT lot_id, MIN(date) AS first_date FROM lot_weighings GROUP BY lot_id
     ) AS firsts ON firsts.lot_id = lots.id
-    WHERE lots.species = 'bovino'${ranchClause}
+    WHERE lots.species = 'bovino'
+      AND COALESCE(lots.status, 'growing') = 'growing'${ranchClause}
   `,
     ...params,
   );
@@ -206,7 +215,8 @@ async function getBovineStatsByLot(ranch?: string): Promise<BovineStats> {
     JOIN lot_weighings latest ON latest.lot_id = lots.id AND latest.date = dates.latest_date
     JOIN lot_weighings prev ON prev.lot_id = lots.id AND prev.date = dates.before_date
     WHERE (dates.latest_date - dates.before_date) > 0
-      AND lots.species = 'bovino'${ranchClause}
+      AND lots.species = 'bovino'
+      AND COALESCE(lots.status, 'growing') = 'growing'${ranchClause}
   `,
     ...params,
   );


### PR DESCRIPTION
## Resumen

Configura la funcionalidad de **venta por lote** para las haciendas en modo **Por Lote**, incluyendo la característica de **estado del lote** con las opciones **En crecimiento**, **Vendido** y **Destruido**.

## Estado del lote

- Nuevo campo `Lot.status` (`growing` por defecto, `sold`, `destroyed`) + campos de venta (`sale_date`, `buyer`, `sale_price`, `sale_comment`).
- Librería `src/lib/lotStatus.ts` con etiquetas y colores de badge.
- Selector de estado en el formulario de lote; al elegir **Vendido** se revelan los datos de venta.
- Etiqueta de estado en la lista y la ficha del lote.
- Migración SQL idempotente `prisma/neon-lot-sales.sql` (con backfill a `growing`).

## Funcionalidad de venta (modo Por Lote)

- La sección **Ventas** es sensible al modo de la hacienda activa:
  - **Por Lote** → lista los lotes vendidos (fecha, comprador, cabezas, peso total, precio/kg y total calculado). No muestra la venta por animales.
  - **Por Animal** → conserva la vista de ventas con ROI.
- **Vender desde la vista de Ventas**: `/sales/new` permite elegir un lote en crecimiento y capturar la venta (acción `sellLot` marca el lote como vendido).
- Botón **Vender lote** en la ficha del lote (solo en modo Por Lote y lote en crecimiento), con preselección vía `?lot_id=`.
- El detalle de cada venta por lote vive en la ficha del lote.

## Métricas

- Las métricas de bovinos en engorde y las cabezas del mapa solo cuentan lotes **en crecimiento**; los vendidos/destruidos salen del inventario activo.
- En modo Por Lote la tarjeta **Ventas** del tablero cuenta los lotes vendidos.

## Verificación

- `npx tsc --noEmit` ✅ sin errores
- `npm run build` ✅ exit 0

> Nota: la migración SQL ya fue aplicada en la base de datos.

https://claude.ai/code/session_01CvLsuywmhYy1P4v7UwKiPY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvLsuywmhYy1P4v7UwKiPY)_