### PR TITLE
Mostrar precios por libra y usar Lempiras como moneda

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ La app puede mostrar y capturar pesos en **kilogramos** o **libras**, con
 **libras como unidad por defecto**. El conmutador está en la barra de
 navegación. Internamente los pesos se almacenan siempre en kilogramos; la
 conversión se aplica solo a la visualización y la captura. Los importes en
-dinero ($/kg, totales) no cambian con la unidad.
+dinero (precio por libra, totales) no cambian con la unidad.
 
 ## 🏷️ Estado y venta del lote (modo Por Lote)
 

--- a/src/app/(app)/animals/[id]/page.tsx
+++ b/src/app/(app)/animals/[id]/page.tsx
@@ -103,8 +103,8 @@ export default async function AnimalShowPage({
                 { label: "Marca / Arete", value: animal.mark ?? "—" },
                 { label: "Proveedor", value: animal.provider ?? "—" },
                 { label: "Nacimiento", value: fmtDate(animal.birthday) },
-                { label: "Precio compra", value: animal.purchasePrice ? `${fmtMoney(animal.purchasePrice)}/kg` : "—" },
-                { label: "Precio venta", value: animal.salePrice ? `${fmtMoney(animal.salePrice)}/kg` : "—" },
+                { label: "Precio compra", value: animal.purchasePrice ? `${fmtMoney(animal.purchasePrice)}/lb` : "—" },
+                { label: "Precio venta", value: animal.salePrice ? `${fmtMoney(animal.salePrice)}/lb` : "—" },
                 {
                   label: "Venta",
                   value: animal.sale ? (

--- a/src/app/(app)/lots/[id]/page.tsx
+++ b/src/app/(app)/lots/[id]/page.tsx
@@ -224,7 +224,7 @@ export default async function LotShowPage({
                       label: "Precio de venta",
                       value:
                         lot.salePrice != null
-                          ? `${fmtMoney(lot.salePrice)}/kg`
+                          ? `${fmtMoney(lot.salePrice)}/lb`
                           : "—",
                     },
                     {

--- a/src/app/(app)/sales/[id]/page.tsx
+++ b/src/app/(app)/sales/[id]/page.tsx
@@ -129,7 +129,7 @@ export default async function SaleShowPage({
                     <Td className="capitalize">{a.species ?? "—"}</Td>
                     <Td>{a.ranch ?? "—"}</Td>
                     <Td className="text-right">
-                      {a.salePrice ? `${fmtMoney(a.salePrice)}/kg` : "—"}
+                      {a.salePrice ? `${fmtMoney(a.salePrice)}/lb` : "—"}
                     </Td>
                     <Td>
                       <Link

--- a/src/app/(app)/sales/page.tsx
+++ b/src/app/(app)/sales/page.tsx
@@ -99,7 +99,7 @@ async function LotSalesPage() {
                   </p>
                   <div className="mt-3 grid grid-cols-2 gap-2 text-center text-sm">
                     <div className="rounded-lg bg-slate-50 py-1.5">
-                      <p className="text-xs text-slate-400">Precio/kg</p>
+                      <p className="text-xs text-slate-400">Precio/lb</p>
                       <p className="font-semibold">
                         {lot.salePrice != null ? fmtMoney(lot.salePrice) : "—"}
                       </p>
@@ -124,7 +124,7 @@ async function LotSalesPage() {
                   <Th>Comprador</Th>
                   <Th className="text-right">Cabezas</Th>
                   <Th className="text-right">Peso total</Th>
-                  <Th className="text-right">Precio/kg</Th>
+                  <Th className="text-right">Precio/lb</Th>
                   <Th className="text-right">Total venta</Th>
                   <Th></Th>
                 </tr>

--- a/src/components/entity-forms/AnimalForm.tsx
+++ b/src/components/entity-forms/AnimalForm.tsx
@@ -100,7 +100,7 @@ export function AnimalForm({
               defaultValue={toDateInput(animal?.birthday)}
             />
           </Field>
-          <Field label="Precio de compra" hint="$/kg al ingreso">
+          <Field label="Precio de compra" hint="$/lb al ingreso">
             <Input
               type="number"
               step="0.01"
@@ -108,7 +108,7 @@ export function AnimalForm({
               defaultValue={animal?.purchasePrice ?? ""}
             />
           </Field>
-          <Field label="Precio de venta" hint="$/kg a la salida">
+          <Field label="Precio de venta" hint="$/lb a la salida">
             <Input
               type="number"
               step="0.01"

--- a/src/components/entity-forms/LotSaleForm.tsx
+++ b/src/components/entity-forms/LotSaleForm.tsx
@@ -42,7 +42,7 @@ export function LotSaleForm({
           <Field label="Comprador">
             <Input name="buyer" />
           </Field>
-          <Field label="Precio de venta" hint="Por kilogramo">
+          <Field label="Precio de venta" hint="Por libra">
             <Input type="number" step="0.01" min="0" name="sale_price" />
           </Field>
         </div>

--- a/src/components/entity-forms/LotStatusFields.tsx
+++ b/src/components/entity-forms/LotStatusFields.tsx
@@ -51,7 +51,7 @@ export function LotStatusFields({ lot }: { lot?: Lot | null }) {
             <Field label="Comprador">
               <Input name="buyer" defaultValue={lot?.buyer ?? ""} />
             </Field>
-            <Field label="Precio de venta" hint="Por kilogramo">
+            <Field label="Precio de venta" hint="Por libra">
               <Input
                 type="number"
                 step="0.01"

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -15,9 +15,9 @@ export function fmtNumber(
 export function fmtMoney(value: number | null | undefined): string {
   if (value === null || value === undefined || Number.isNaN(Number(value)))
     return "—";
-  return Number(value).toLocaleString("es-MX", {
+  return Number(value).toLocaleString("es-HN", {
     style: "currency",
-    currency: "MXN",
+    currency: "HNL",
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,
   });


### PR DESCRIPTION
## Resumen

- Cambia las etiquetas de precio de `$/kg` / "Por kilogramo" a **por libra** en los formularios y vistas de animales, lotes y ventas.
- Cambia el formato de moneda de **MXN** a **Lempiras (HNL)** en `fmtMoney`.

## Detalle

- `LotSaleForm.tsx`, `LotStatusFields.tsx`: "Por kilogramo" → "Por libra"
- `AnimalForm.tsx`: "$/kg al ingreso" / "$/kg a la salida" → "$/lb …"
- Vistas de detalle de animal, lote, ventas y la lista de ventas: `/kg` → `/lb`, "Precio/kg" → "Precio/lb"
- `src/lib/utils.ts`: `currency: "MXN"` → `"HNL"`, locale `es-MX` → `es-HN`
- README actualizado

## ⚠️ Nota

Solo se cambió el texto; **los valores no se convierten**. El precio se sigue guardando y multiplicando internamente como por kilogramo, por lo que los totales/ganancia/ROI quedan numéricamente inconsistentes con la etiqueta "por libra". Cambio solicitado explícitamente así.

https://claude.ai/code/session_016b2So7osDvrt8im1uarSRH

---
_Generated by [Claude Code](https://claude.ai/code/session_016b2So7osDvrt8im1uarSRH)_