### PR TITLE
Ocultar menciones a animales individuales en modo Por Lote

### DIFF
--- a/src/app/(app)/haciendas/[id]/page.tsx
+++ b/src/app/(app)/haciendas/[id]/page.tsx
@@ -7,7 +7,7 @@ import { Card, DescList, StatCard } from "@/components/ui";
 import { DeleteButton } from "@/components/DeleteButton";
 import { ArrowLeftIcon, EditIcon, CowIcon, LotsIcon, PlotIcon, SettingsIcon } from "@/components/icons";
 import { fmtNumber } from "@/lib/utils";
-import { weightModeLabel } from "@/lib/weightMode";
+import { weightModeLabel, normalizeWeightMode } from "@/lib/weightMode";
 import { parseGeoJsonRing } from "@/lib/kml";
 import { HaciendaPlotsMap } from "@/components/HaciendaPlotsMap";
 
@@ -51,6 +51,10 @@ export default async function HaciendaShowPage({
   const canEdit = isEditor(user?.role);
   const canDelete = isAdmin(user?.role);
 
+  // En las haciendas configuradas "Por Lote" no se gestionan animales
+  // individuales, así que se oculta la tarjeta de "Animales".
+  const showAnimals = normalizeWeightMode(hacienda.weightMode) !== "lot";
+
   return (
     <div>
       <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
@@ -91,14 +95,20 @@ export default async function HaciendaShowPage({
         {hacienda.name}
       </h1>
 
-      <div className="mb-6 grid grid-cols-3 gap-3 sm:gap-4">
-        <StatCard
-          label="Animales"
-          value={fmtNumber(animals)}
-          icon={<CowIcon width={22} height={22} />}
-          href="/animals"
-          accent="brand"
-        />
+      <div
+        className={`mb-6 grid gap-3 sm:gap-4 ${
+          showAnimals ? "grid-cols-3" : "grid-cols-2"
+        }`}
+      >
+        {showAnimals && (
+          <StatCard
+            label="Animales"
+            value={fmtNumber(animals)}
+            icon={<CowIcon width={22} height={22} />}
+            href="/animals"
+            accent="brand"
+          />
+        )}
         <StatCard
           label="Lotes"
           value={fmtNumber(lots)}

--- a/src/app/(app)/lots/[id]/page.tsx
+++ b/src/app/(app)/lots/[id]/page.tsx
@@ -203,7 +203,16 @@ export default async function LotShowPage({
                     },
                   ]
                 : []),
-              { label: "Animales registrados", value: <Badge color="slate">{lot.animals.length}</Badge> },
+              // En modo "Por Lote" no se gestionan animales individuales, así
+              // que se omite el conteo de animales registrados del lote.
+              ...(weightMode !== "lot"
+                ? [
+                    {
+                      label: "Animales registrados",
+                      value: <Badge color="slate">{lot.animals.length}</Badge>,
+                    },
+                  ]
+                : []),
               { label: "Descripción", value: lot.description ?? "—" },
             ]}
           />
@@ -326,52 +335,56 @@ export default async function LotShowPage({
             )}
           </div>
 
-          <div>
-            <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-400">
-              Animales del lote
-            </h2>
-            {lot.animals.length === 0 ? (
-              <EmptyState
-                icon={<CowIcon width={24} height={24} />}
-                title="Sin animales"
-                description="Asigna animales a este lote desde la ficha de cada animal."
-              />
-            ) : (
-              <TableWrap>
-                <thead>
-                  <tr>
-                    <Th>#</Th>
-                    <Th>Especie</Th>
-                    <Th>Estatus</Th>
-                    <Th></Th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {lot.animals.map((a) => (
-                    <tr key={a.id} className="hover:bg-slate-50">
-                      <Td className="font-semibold text-slate-900">
-                        {a.animalNumber ?? a.id}
-                      </Td>
-                      <Td className="capitalize">{a.species ?? "—"}</Td>
-                      <Td>
-                        <Badge color={a.status === "engorde" ? "green" : "slate"}>
-                          {a.status ?? "—"}
-                        </Badge>
-                      </Td>
-                      <Td>
-                        <Link
-                          href={`/animals/${a.id}`}
-                          className="inline-flex text-brand-600"
-                        >
-                          <ChevronRightIcon />
-                        </Link>
-                      </Td>
+          {/* La lista de animales individuales del lote solo aplica en modo
+              "Por Animal"; en modo "Por Lote" se oculta por completo. */}
+          {weightMode !== "lot" && (
+            <div>
+              <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-400">
+                Animales del lote
+              </h2>
+              {lot.animals.length === 0 ? (
+                <EmptyState
+                  icon={<CowIcon width={24} height={24} />}
+                  title="Sin animales"
+                  description="Asigna animales a este lote desde la ficha de cada animal."
+                />
+              ) : (
+                <TableWrap>
+                  <thead>
+                    <tr>
+                      <Th>#</Th>
+                      <Th>Especie</Th>
+                      <Th>Estatus</Th>
+                      <Th></Th>
                     </tr>
-                  ))}
-                </tbody>
-              </TableWrap>
-            )}
-          </div>
+                  </thead>
+                  <tbody>
+                    {lot.animals.map((a) => (
+                      <tr key={a.id} className="hover:bg-slate-50">
+                        <Td className="font-semibold text-slate-900">
+                          {a.animalNumber ?? a.id}
+                        </Td>
+                        <Td className="capitalize">{a.species ?? "—"}</Td>
+                        <Td>
+                          <Badge color={a.status === "engorde" ? "green" : "slate"}>
+                            {a.status ?? "—"}
+                          </Badge>
+                        </Td>
+                        <Td>
+                          <Link
+                            href={`/animals/${a.id}`}
+                            className="inline-flex text-brand-600"
+                          >
+                            <ChevronRightIcon />
+                          </Link>
+                        </Td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </TableWrap>
+              )}
+            </div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
En las haciendas configuradas **Por Lote** no se gestionan animales individuales. Esta PR oculta las menciones individuales a animales que aún quedaban visibles en ese modo.

## Cambios

**Ficha del lote** (`lots/[id]/page.tsx`)
- Se omite el item **"Animales registrados"** del detalle.
- Se oculta por completo la sección **"Animales del lote"** (tabla con número, especie, estatus y enlace a cada animal).

**Ficha de la hacienda** (`haciendas/[id]/page.tsx`)
- Se oculta la tarjeta **"Animales"** cuando la hacienda está configurada Por Lote (según su propio `weightMode`), ajustando la cuadrícula de 3 a 2 columnas.

Las referencias a **"cabezas"** (headcount del último pesado) se conservan a propósito: representan el conteo agregado del lote, no animales individuales.

## Verificación
- `npx tsc --noEmit` pasa sin errores.

https://claude.ai/code/session_01WMRxDqYq71khY1iqqP8Zkb

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMRxDqYq71khY1iqqP8Zkb)_