### PR TITLE
Eliminar la variable de especie de todo el sistema

### DIFF
--- a/prisma/neon-setup.sql
+++ b/prisma/neon-setup.sql
@@ -13,7 +13,6 @@ CREATE SCHEMA IF NOT EXISTS "public";
 CREATE TABLE "animals" (
     "id" SERIAL NOT NULL,
     "animal_number" INTEGER,
-    "species" TEXT,
     "birthday" DATE,
     "ranch" TEXT,
     "lot_id" INTEGER,
@@ -35,7 +34,6 @@ CREATE TABLE "animals" (
 CREATE TABLE "lots" (
     "id" SERIAL NOT NULL,
     "ranch" TEXT,
-    "species" TEXT,
     "number" TEXT,
     "name" TEXT,
     "description" TEXT,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,7 +15,6 @@ datasource db {
 model Animal {
   id            Int       @id @default(autoincrement())
   animalNumber  Int?      @map("animal_number")
-  species       String?
   birthday      DateTime? @db.Date
   ranch         String?
   lotId         Int?      @map("lot_id")
@@ -55,7 +54,6 @@ model Hacienda {
 model Lot {
   id          Int      @id @default(autoincrement())
   ranch       String?
-  species     String?
   number      String?
   name        String?
   description String?

--- a/src/actions/animals.ts
+++ b/src/actions/animals.ts
@@ -9,7 +9,6 @@ import { str, int, float, date } from "@/actions/helpers";
 function animalData(formData: FormData) {
   return {
     animalNumber: int(formData.get("animal_number")),
-    species: str(formData.get("species")),
     birthday: date(formData.get("birthday")),
     ranch: str(formData.get("ranch")),
     lotId: int(formData.get("lot_id")),

--- a/src/actions/lots.ts
+++ b/src/actions/lots.ts
@@ -14,7 +14,6 @@ function lotData(formData: FormData) {
   const sold = status === "sold";
   return {
     ranch: str(formData.get("ranch")),
-    species: str(formData.get("species")),
     number: str(formData.get("number")),
     name: str(formData.get("name")),
     description: str(formData.get("description")),

--- a/src/app/(app)/animals/[id]/page.tsx
+++ b/src/app/(app)/animals/[id]/page.tsx
@@ -86,7 +86,6 @@ export default async function AnimalShowPage({
           <Card>
             <DescList
               items={[
-                { label: "Especie", value: <span className="capitalize">{animal.species ?? "—"}</span> },
                 { label: "Hacienda", value: animal.ranch ?? "—" },
                 {
                   label: "Lote",

--- a/src/app/(app)/animals/page.tsx
+++ b/src/app/(app)/animals/page.tsx
@@ -84,7 +84,7 @@ export default async function AnimalsPage({
           <input
             name="search"
             defaultValue={sp.search ?? ""}
-            placeholder="Buscar por número, especie o hacienda…"
+            placeholder="Buscar por número o hacienda…"
             className="w-full rounded-xl border border-slate-300 bg-white py-2.5 pl-10 pr-3 text-base shadow-sm focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20"
           />
         </div>
@@ -135,7 +135,7 @@ export default async function AnimalsPage({
                         #{r.animal_number}
                       </p>
                       <p className="text-xs text-slate-500">
-                        {r.ranch} · {r.species}
+                        {r.ranch}
                         {r.lot_number ? ` · Lote ${r.lot_number}` : ""}
                       </p>
                     </div>
@@ -167,7 +167,6 @@ export default async function AnimalsPage({
                 <tr>
                   <Th>#</Th>
                   <Th>Hacienda</Th>
-                  <Th>Especie</Th>
                   <Th>Lote</Th>
                   <Th className="text-right">Último peso</Th>
                   <Th className="text-right">Anterior</Th>
@@ -184,7 +183,6 @@ export default async function AnimalsPage({
                       {r.animal_number}
                     </Td>
                     <Td>{r.ranch}</Td>
-                    <Td className="capitalize">{r.species}</Td>
                     <Td>{r.lot_number ?? "—"}</Td>
                     <Td className="text-right font-semibold">
                       {fmtWeight(r.last_weight, unit)}

--- a/src/app/(app)/lot_weighings/[id]/edit/page.tsx
+++ b/src/app/(app)/lot_weighings/[id]/edit/page.tsx
@@ -23,7 +23,7 @@ export default async function EditLotWeighingPage({
     prisma.lotWeighing.findUnique({ where: { id: weighingId } }),
     prisma.lot.findMany({
       orderBy: [{ ranch: "asc" }, { number: "asc" }],
-      select: { id: true, number: true, name: true, ranch: true, species: true },
+      select: { id: true, number: true, name: true, ranch: true },
     }),
     getWeightUnit(),
   ]);

--- a/src/app/(app)/lot_weighings/new/page.tsx
+++ b/src/app/(app)/lot_weighings/new/page.tsx
@@ -18,7 +18,7 @@ export default async function NewLotWeighingPage({
   const [lots, unit] = await Promise.all([
     prisma.lot.findMany({
       orderBy: [{ ranch: "asc" }, { number: "asc" }],
-      select: { id: true, number: true, name: true, ranch: true, species: true },
+      select: { id: true, number: true, name: true, ranch: true },
     }),
     getWeightUnit(),
   ]);

--- a/src/app/(app)/lots/[id]/page.tsx
+++ b/src/app/(app)/lots/[id]/page.tsx
@@ -170,7 +170,6 @@ export default async function LotShowPage({
                   "—"
                 ),
               },
-              { label: "Especie", value: <span className="capitalize">{lot.species ?? "—"}</span> },
               {
                 label: "Peso promedio",
                 value: fmtWeight(latest?.averageWeight ?? null, unit),
@@ -353,7 +352,6 @@ export default async function LotShowPage({
                   <thead>
                     <tr>
                       <Th>#</Th>
-                      <Th>Especie</Th>
                       <Th>Estatus</Th>
                       <Th></Th>
                     </tr>
@@ -364,7 +362,6 @@ export default async function LotShowPage({
                         <Td className="font-semibold text-slate-900">
                           {a.animalNumber ?? a.id}
                         </Td>
-                        <Td className="capitalize">{a.species ?? "—"}</Td>
                         <Td>
                           <Badge color={a.status === "engorde" ? "green" : "slate"}>
                             {a.status ?? "—"}

--- a/src/app/(app)/lots/page.tsx
+++ b/src/app/(app)/lots/page.tsx
@@ -15,7 +15,7 @@ export default async function LotsPage() {
   const [lots, unit, user] = await Promise.all([
     prisma.lot.findMany({
       where: activeHacienda ? { ranch: activeHacienda } : undefined,
-      orderBy: [{ ranch: "asc" }, { species: "asc" }, { number: "asc" }],
+      orderBy: [{ ranch: "asc" }, { number: "asc" }],
       include: {
         _count: { select: { animals: true } },
         plot: { select: { id: true, number: true } },
@@ -68,7 +68,6 @@ export default async function LotsPage() {
                     <p className="text-xs text-slate-500">
                       {[
                         lot.ranch,
-                        lot.species,
                         lot.plot?.number ? `Potrero ${lot.plot.number}` : null,
                       ]
                         .filter(Boolean)
@@ -101,7 +100,6 @@ export default async function LotsPage() {
                   <Th>Estado</Th>
                   <Th>Hacienda</Th>
                   <Th>Potrero</Th>
-                  <Th>Especie</Th>
                   <Th className="text-right">Cabezas</Th>
                   <Th className="text-right">Peso promedio</Th>
                   <Th className="text-right">Último pesado</Th>
@@ -125,7 +123,6 @@ export default async function LotsPage() {
                       <Td>
                         {lot.plot?.number ? `Potrero ${lot.plot.number}` : "—"}
                       </Td>
-                      <Td className="capitalize">{lot.species ?? "—"}</Td>
                       <Td className="text-right">
                         {latest?.animalCount ?? lot._count.animals}
                       </Td>

--- a/src/app/(app)/sales/[id]/page.tsx
+++ b/src/app/(app)/sales/[id]/page.tsx
@@ -114,7 +114,6 @@ export default async function SaleShowPage({
               <thead>
                 <tr>
                   <Th>#</Th>
-                  <Th>Especie</Th>
                   <Th>Hacienda</Th>
                   <Th className="text-right">Precio venta</Th>
                   <Th></Th>
@@ -126,7 +125,6 @@ export default async function SaleShowPage({
                     <Td className="font-semibold text-slate-900">
                       {a.animalNumber ?? a.id}
                     </Td>
-                    <Td className="capitalize">{a.species ?? "—"}</Td>
                     <Td>{a.ranch ?? "—"}</Td>
                     <Td className="text-right">
                       {a.salePrice ? `${fmtMoney(a.salePrice)}/lb` : "—"}

--- a/src/app/(app)/weights/[id]/edit/page.tsx
+++ b/src/app/(app)/weights/[id]/edit/page.tsx
@@ -23,7 +23,7 @@ export default async function EditWeightPage({
     prisma.weight.findUnique({ where: { id: weightId } }),
     prisma.animal.findMany({
       orderBy: [{ ranch: "asc" }, { animalNumber: "asc" }],
-      select: { id: true, animalNumber: true, ranch: true, species: true },
+      select: { id: true, animalNumber: true, ranch: true },
     }),
     getWeightUnit(),
   ]);

--- a/src/app/(app)/weights/new/page.tsx
+++ b/src/app/(app)/weights/new/page.tsx
@@ -18,7 +18,7 @@ export default async function NewWeightPage({
   const [animals, unit] = await Promise.all([
     prisma.animal.findMany({
       orderBy: [{ ranch: "asc" }, { animalNumber: "asc" }],
-      select: { id: true, animalNumber: true, ranch: true, species: true },
+      select: { id: true, animalNumber: true, ranch: true },
     }),
     getWeightUnit(),
   ]);

--- a/src/components/entity-forms/AnimalForm.tsx
+++ b/src/components/entity-forms/AnimalForm.tsx
@@ -5,7 +5,6 @@ import { Field, Input, Select, SubmitButton } from "@/components/forms";
 import { RanchSelect } from "@/components/RanchSelect";
 import { toDateInput } from "@/lib/utils";
 
-const SPECIES = ["bovino", "ovino", "caprino", "equino", "porcino"];
 const STATUSES = ["engorde", "cría", "reproducción", "vendido", "muerto"];
 
 export function AnimalForm({
@@ -35,15 +34,6 @@ export function AnimalForm({
               placeholder="Ej. 1024"
             />
           </Field>
-          <Field label="Especie">
-            <Select name="species" defaultValue={animal?.species ?? "bovino"}>
-              {SPECIES.map((s) => (
-                <option key={s} value={s}>
-                  {s}
-                </option>
-              ))}
-            </Select>
-          </Field>
           <Field label="Hacienda">
             <RanchSelect haciendas={haciendas} defaultValue={animal?.ranch} />
           </Field>
@@ -61,7 +51,7 @@ export function AnimalForm({
               <option value="">— Sin lote —</option>
               {lots.map((l) => (
                 <option key={l.id} value={l.id}>
-                  {[l.ranch, l.species, l.number].filter(Boolean).join(" · ")}
+                  {[l.ranch, l.number].filter(Boolean).join(" · ")}
                 </option>
               ))}
             </Select>

--- a/src/components/entity-forms/LotForm.tsx
+++ b/src/components/entity-forms/LotForm.tsx
@@ -5,8 +5,6 @@ import { Field, Input, Select, Textarea, SubmitButton } from "@/components/forms
 import { RanchSelect } from "@/components/RanchSelect";
 import { LotStatusFields } from "@/components/entity-forms/LotStatusFields";
 
-const SPECIES = ["bovino", "ovino", "caprino", "equino", "porcino"];
-
 export function LotForm({
   action,
   lot,
@@ -32,15 +30,6 @@ export function LotForm({
           </Field>
           <Field label="Hacienda">
             <RanchSelect haciendas={haciendas} defaultValue={lot?.ranch} />
-          </Field>
-          <Field label="Especie">
-            <Select name="species" defaultValue={lot?.species ?? "bovino"}>
-              {SPECIES.map((s) => (
-                <option key={s} value={s}>
-                  {s}
-                </option>
-              ))}
-            </Select>
           </Field>
           <Field label="Potrero" hint="Ubicación del lote">
             <Select name="plot_id" defaultValue={lot?.plotId ?? ""}>

--- a/src/components/entity-forms/LotWeighingForm.tsx
+++ b/src/components/entity-forms/LotWeighingForm.tsx
@@ -16,7 +16,7 @@ export function LotWeighingForm({
 }: {
   action: (formData: FormData) => void | Promise<void>;
   weighing?: LotWeighing | null;
-  lots: Pick<Lot, "id" | "number" | "name" | "ranch" | "species">[];
+  lots: Pick<Lot, "id" | "number" | "name" | "ranch">[];
   defaultLotId?: number;
   unit: WeightUnit;
   submitLabel: string;
@@ -35,7 +35,7 @@ export function LotWeighingForm({
             <option value="">— Selecciona un lote —</option>
             {lots.map((l) => (
               <option key={l.id} value={l.id}>
-                {[l.name || l.number || `#${l.id}`, l.ranch, l.species]
+                {[l.name || l.number || `#${l.id}`, l.ranch]
                   .filter(Boolean)
                   .join(" · ")}
               </option>

--- a/src/components/entity-forms/WeightForm.tsx
+++ b/src/components/entity-forms/WeightForm.tsx
@@ -16,7 +16,7 @@ export function WeightForm({
 }: {
   action: (formData: FormData) => void | Promise<void>;
   weight?: Weight | null;
-  animals: Pick<Animal, "id" | "animalNumber" | "ranch" | "species">[];
+  animals: Pick<Animal, "id" | "animalNumber" | "ranch">[];
   defaultAnimalId?: number;
   unit: WeightUnit;
   submitLabel: string;
@@ -35,7 +35,7 @@ export function WeightForm({
             <option value="">— Selecciona un animal —</option>
             {animals.map((a) => (
               <option key={a.id} value={a.id}>
-                {[`#${a.animalNumber ?? a.id}`, a.ranch, a.species]
+                {[`#${a.animalNumber ?? a.id}`, a.ranch]
                   .filter(Boolean)
                   .join(" · ")}
               </option>

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -82,13 +82,12 @@ async function getBovineStatsByAnimal(ranch?: string): Promise<BovineStats> {
   const ranchClause = ranch ? ` AND animals.ranch = $1` : "";
   const params: unknown[] = ranch ? [ranch] : [];
 
-  // Peso promedio y conteo por especie (solo animales en engorde).
+  // Peso promedio y conteo de animales en engorde.
   const avgWeight = await prisma.$queryRawUnsafe<
-    { species: string; count: number; average_weight: number }[]
+    { count: number; average_weight: number }[]
   >(
     `
-    SELECT animals.species AS species,
-           COUNT(DISTINCT animals.id)::float8 AS count,
+    SELECT COUNT(DISTINCT animals.id)::float8 AS count,
            AVG(weights.weight)::float8 AS average_weight
     FROM animals
     JOIN weights ON weights.animal_id = animals.id
@@ -104,18 +103,14 @@ async function getBovineStatsByAnimal(ranch?: string): Promise<BovineStats> {
     ) AS dates ON weights.animal_id = dates.animal_id AND weights.date = dates.latest_date
     JOIN weights w2 ON w2.animal_id = dates.animal_id AND w2.date = dates.before_date
     WHERE animals.status = 'engorde'${ranchClause}
-    GROUP BY animals.species
   `,
     ...params,
   );
 
-  // Ganancia diaria de peso (GDP) por especie.
-  const dailyGain = await prisma.$queryRawUnsafe<
-    { species: string; daily_gain: number }[]
-  >(
+  // Ganancia diaria de peso (GDP) promedio.
+  const dailyGain = await prisma.$queryRawUnsafe<{ daily_gain: number }[]>(
     `
-    SELECT animals.species AS species,
-           AVG(COALESCE((weights.weight - w2.weight) / NULLIF((dates.latest_date - dates.before_date), 0), 0))::float8 AS daily_gain
+    SELECT AVG(COALESCE((weights.weight - w2.weight) / NULLIF((dates.latest_date - dates.before_date), 0), 0))::float8 AS daily_gain
     FROM animals
     JOIN weights ON weights.animal_id = animals.id
     JOIN (
@@ -131,38 +126,31 @@ async function getBovineStatsByAnimal(ranch?: string): Promise<BovineStats> {
     JOIN weights w2 ON w2.animal_id = dates.animal_id AND w2.date = dates.before_date
     WHERE (dates.latest_date - dates.before_date) > 0
       AND animals.status = 'engorde'${ranchClause}
-    GROUP BY animals.species
   `,
     ...params,
   );
 
-  // Días desde el ingreso (promedio) por especie.
+  // Días desde el ingreso (promedio).
   const daysInRanch = await prisma.$queryRawUnsafe<
-    { species: string; days_in_ranch: number }[]
+    { days_in_ranch: number }[]
   >(
     `
-    SELECT animals.species AS species,
-           AVG(w.days_in_ranch)::float8 AS days_in_ranch
+    SELECT AVG(w.days_in_ranch)::float8 AS days_in_ranch
     FROM animals
     JOIN (
       SELECT animal_id, date(NOW()) - MIN(weights.date) AS days_in_ranch
       FROM weights GROUP BY animal_id
     ) AS w ON w.animal_id = animals.id
     WHERE animals.status = 'engorde'${ranchClause}
-    GROUP BY animals.species
   `,
     ...params,
   );
 
-  const bovineAvg = avgWeight.find((r) => r.species === "bovino");
-  const bovineGain = dailyGain.find((r) => r.species === "bovino");
-  const bovineDays = daysInRanch.find((r) => r.species === "bovino");
-
   return {
-    count: toNum(bovineAvg?.count) ?? 0,
-    averageWeight: toNum(bovineAvg?.average_weight) ?? 0,
-    dailyGain: toNum(bovineGain?.daily_gain) ?? 0,
-    daysInRanch: toNum(bovineDays?.days_in_ranch) ?? 0,
+    count: toNum(avgWeight[0]?.count) ?? 0,
+    averageWeight: toNum(avgWeight[0]?.average_weight) ?? 0,
+    dailyGain: toNum(dailyGain[0]?.daily_gain) ?? 0,
+    daysInRanch: toNum(daysInRanch[0]?.days_in_ranch) ?? 0,
   };
 }
 
@@ -200,8 +188,7 @@ async function getBovineStatsByLot(ranch?: string): Promise<BovineStats> {
     JOIN (
       SELECT lot_id, MIN(date) AS first_date FROM lot_weighings GROUP BY lot_id
     ) AS firsts ON firsts.lot_id = lots.id
-    WHERE lots.species = 'bovino'
-      AND COALESCE(lots.status, 'growing') = 'growing'${ranchClause}
+    WHERE COALESCE(lots.status, 'growing') = 'growing'${ranchClause}
   `,
     ...params,
   );
@@ -215,7 +202,6 @@ async function getBovineStatsByLot(ranch?: string): Promise<BovineStats> {
     JOIN lot_weighings latest ON latest.lot_id = lots.id AND latest.date = dates.latest_date
     JOIN lot_weighings prev ON prev.lot_id = lots.id AND prev.date = dates.before_date
     WHERE (dates.latest_date - dates.before_date) > 0
-      AND lots.species = 'bovino'
       AND COALESCE(lots.status, 'growing') = 'growing'${ranchClause}
   `,
     ...params,
@@ -234,7 +220,6 @@ export type LatestWeightRow = {
   animal_id: number;
   animal_number: number;
   ranch: string;
-  species: string;
   lot_id: number | null;
   lot_number: string | null;
   latest_date: Date;
@@ -253,7 +238,6 @@ export type LatestWeightRow = {
 const SORT_COLUMNS: Record<string, string> = {
   animal_number: "animal_number",
   ranch: "ranch",
-  species: "species",
   last_weight: "last_weight",
   days_since_last_weight: "days_since_last_weight",
   daily_gain: "daily_gain",
@@ -300,7 +284,7 @@ export async function getLatestWeights(opts: {
   const search = opts.search?.trim();
   if (search) {
     params.push(search);
-    filterClause += ` AND (CAST(animals.animal_number AS text) = $${params.length} OR animals.species ILIKE $${params.length} OR animals.ranch ILIKE $${params.length})`;
+    filterClause += ` AND (CAST(animals.animal_number AS text) = $${params.length} OR animals.ranch ILIKE $${params.length})`;
   }
 
   const ranch = opts.ranch?.trim();
@@ -315,7 +299,6 @@ export async function getLatestWeights(opts: {
       weights.animal_id AS animal_id,
       animals.animal_number AS animal_number,
       animals.ranch AS ranch,
-      animals.species AS species,
       animals.lot_id AS lot_id,
       lots.number AS lot_number,
       dates.latest_date AS latest_date,
@@ -359,7 +342,6 @@ export async function getLatestWeights(opts: {
 
 export type LotStatRow = {
   ranch: string | null;
-  species: string | null;
   lot_id: number | null;
   number: string | null;
   name: string | null;
@@ -374,7 +356,6 @@ export async function getLotStats(): Promise<LotStatRow[]> {
   const rows = await prisma.$queryRawUnsafe<LotStatRow[]>(`
     SELECT
       lots.ranch AS ranch,
-      lots.species AS species,
       animals.lot_id AS lot_id,
       lots.number AS number,
       lots.name AS name,
@@ -396,8 +377,8 @@ export async function getLotStats(): Promise<LotStatRow[]> {
       GROUP BY animal_id
     ) AS dates ON weights.animal_id = dates.animal_id AND weights.date = dates.latest_date
     JOIN weights w2 ON w2.animal_id = dates.animal_id AND w2.date = dates.before_date
-    GROUP BY lots.ranch, lots.species, animals.lot_id, lots.number, lots.name
-    ORDER BY lots.ranch, lots.species, lots.number
+    GROUP BY lots.ranch, animals.lot_id, lots.number, lots.name
+    ORDER BY lots.ranch, lots.number
   `);
   return rows.map((r) => ({
     ...r,


### PR DESCRIPTION
Quita el campo `species` ("Especie") de todo el sistema.

## Cambios por capa

**Base de datos / esquema**
- `prisma/schema.prisma`: campo `species` eliminado de los modelos `Animal` y `Lot`.
- `prisma/neon-setup.sql`: columna `"species" TEXT` quitada de las tablas `animals` y `lots`.

**Lógica de servidor**
- `src/actions/animals.ts` y `src/actions/lots.ts`: ya no leen ni guardan `species`.
- `src/lib/queries.ts`: las estadísticas del dashboard ya no filtran por `species = 'bovino'` ni agrupan por especie; las métricas en engorde consideran todos los animales/lotes. Se quitó `species` de los tipos `LatestWeightRow` y `LotStatRow`, del buscador, del orden y de los `SELECT`/`GROUP BY`.

**Formularios**
- `AnimalForm`, `LotForm`: eliminado el campo "Especie" y la lista `SPECIES`.
- `WeightForm`, `LotWeighingForm`: quitado `species` de los selectores.

**Vistas**
- Listados y fichas de animales, lotes y ventas: columna/dato "Especie" eliminado; buscador de animales actualizado.

## Verificación
- `tsc --noEmit` sin errores.
- `next build` exitoso.

## Nota para base de datos existente
La columna `species` queda huérfana e inofensiva en bases ya creadas. Para eliminarla físicamente:
```sql
ALTER TABLE "animals" DROP COLUMN IF EXISTS "species";
ALTER TABLE "lots"    DROP COLUMN IF EXISTS "species";
```

https://claude.ai/code/session_01K6fk8z7Bs93Y83TLboYccj

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6fk8z7Bs93Y83TLboYccj)_