### PR TITLE
Corrales (ubicación puntual) con asignación de lotes e importación KMZ

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,29 @@ exportado de Google Earth. Cada polígono se convierte en un potrero:
 - Si ya existe un potrero con ese número (y misma hacienda) se **actualiza**;
   si no, se **crea**.
 
+## 📍 Corrales (ubicación puntual)
+
+A diferencia de un **potrero** (un polígono con linderos), un **corral** es una
+**ubicación puntual** definida por **latitud y longitud**. Los lotes de ganado
+pueden asignarse a un corral igual que a un potrero (un lote puede tener
+potrero, corral, ambos o ninguno).
+
+Desde **Corrales** puedes crear, editar y eliminar corrales, y ver su ubicación
+en un mapa satelital con un marcador. La ficha de cada corral muestra los lotes
+asignados y el total de cabezas.
+
+Desde **Corrales → Importar KMZ** puedes subir un archivo `.kmz` o `.kml` de
+Google Earth. Cada **punto/marcador** se convierte en un corral:
+
+- El **nombre** del punto se usa como número de corral.
+- Las **coordenadas** del punto se guardan como latitud y longitud.
+- Si ya existe un corral con ese número (y misma hacienda) se **actualiza**;
+  si no, se **crea**.
+
+> Migración de BD: si ya tienes la base de datos creada, aplica
+> `prisma/neon-corrals.sql` en el SQL Editor de Neon (o corre `npm run db:push`)
+> para agregar la tabla `corrals` y la columna `lots.corral_id`.
+
 ## ⚖️ Unidad de peso (kg / lb)
 
 La app puede mostrar y capturar pesos en **kilogramos** o **libras**, con

--- a/prisma/neon-corrals.sql
+++ b/prisma/neon-corrals.sql
@@ -1,0 +1,42 @@
+-- ============================================================================
+-- Migración incremental: corrales (encierros) con ubicación puntual.
+-- Pega TODO este archivo en: Neon Dashboard -> SQL Editor -> Run
+-- (o aplica el esquema con `npm run db:push`).
+--
+-- Agrega:
+--   - tabla "corrals"   -> corral con ubicación puntual (latitud/longitud)
+--   - lots.corral_id    -> corral asignado al lote (análogo a plot_id)
+-- Es idempotente: se puede correr varias veces sin error.
+-- ============================================================================
+
+-- Corral: ubicación puntual (a diferencia del potrero, que es un polígono).
+CREATE TABLE IF NOT EXISTS "corrals" (
+    "id" SERIAL NOT NULL,
+    "number" TEXT,
+    "ranch" TEXT,
+    "comment" TEXT,
+    "latitude" DOUBLE PRECISION,
+    "longitude" DOUBLE PRECISION,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "corrals_pkey" PRIMARY KEY ("id")
+);
+
+-- Ubicación del lote: corral asignado.
+ALTER TABLE "lots" ADD COLUMN IF NOT EXISTS "corral_id" INTEGER;
+
+CREATE INDEX IF NOT EXISTS "lots_corral_id_idx" ON "lots"("corral_id");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'lots_corral_id_fkey'
+  ) THEN
+    ALTER TABLE "lots"
+      ADD CONSTRAINT "lots_corral_id_fkey"
+      FOREIGN KEY ("corral_id") REFERENCES "corrals"("id")
+      ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/prisma/neon-setup.sql
+++ b/prisma/neon-setup.sql
@@ -38,6 +38,7 @@ CREATE TABLE "lots" (
     "name" TEXT,
     "description" TEXT,
     "plot_id" INTEGER,
+    "corral_id" INTEGER,
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
@@ -89,6 +90,20 @@ CREATE TABLE "plots" (
 );
 
 -- CreateTable
+CREATE TABLE "corrals" (
+    "id" SERIAL NOT NULL,
+    "number" TEXT,
+    "ranch" TEXT,
+    "comment" TEXT,
+    "latitude" DOUBLE PRECISION,
+    "longitude" DOUBLE PRECISION,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "corrals_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
 CREATE TABLE "sales" (
     "id" SERIAL NOT NULL,
     "date" DATE,
@@ -137,6 +152,9 @@ CREATE INDEX "animals_sale_id_idx" ON "animals"("sale_id");
 CREATE INDEX "lots_plot_id_idx" ON "lots"("plot_id");
 
 -- CreateIndex
+CREATE INDEX "lots_corral_id_idx" ON "lots"("corral_id");
+
+-- CreateIndex
 CREATE INDEX "lot_weighings_lot_id_idx" ON "lot_weighings"("lot_id");
 
 -- CreateIndex
@@ -156,6 +174,9 @@ ALTER TABLE "animals" ADD CONSTRAINT "animals_sale_id_fkey" FOREIGN KEY ("sale_i
 
 -- AddForeignKey
 ALTER TABLE "lots" ADD CONSTRAINT "lots_plot_id_fkey" FOREIGN KEY ("plot_id") REFERENCES "plots"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "lots" ADD CONSTRAINT "lots_corral_id_fkey" FOREIGN KEY ("corral_id") REFERENCES "corrals"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "lot_weighings" ADD CONSTRAINT "lot_weighings_lot_id_fkey" FOREIGN KEY ("lot_id") REFERENCES "lots"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,6 +58,7 @@ model Lot {
   name        String?
   description String?
   plotId      Int?     @map("plot_id")
+  corralId    Int?     @map("corral_id")
   // Estado del lote en modo "Por Lote": "growing" (en crecimiento), "sold"
   // (vendido) o "destroyed" (destruido). Solo los lotes en crecimiento cuentan
   // como inventario activo en engorde.
@@ -72,10 +73,12 @@ model Lot {
   updatedAt   DateTime @default(now()) @updatedAt @map("updated_at")
 
   plot      Plot?         @relation(fields: [plotId], references: [id])
+  corral    Corral?       @relation(fields: [corralId], references: [id])
   animals   Animal[]
   weighings LotWeighing[]
 
   @@index([plotId])
+  @@index([corralId])
   @@map("lots")
 }
 
@@ -127,6 +130,24 @@ model Plot {
   lots        Lot[]
 
   @@map("plots")
+}
+
+// Corral (encierro/comedero): a diferencia de un potrero (polígono), es una
+// ubicación puntual definida por latitud/longitud. Los lotes de ganado pueden
+// asignarse a un corral igual que a un potrero.
+model Corral {
+  id        Int      @id @default(autoincrement())
+  number    String?
+  ranch     String?
+  comment   String?
+  latitude  Float?
+  longitude Float?
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
+
+  lots Lot[]
+
+  @@map("corrals")
 }
 
 model Sale {

--- a/src/actions/corrals.ts
+++ b/src/actions/corrals.ts
@@ -1,0 +1,114 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { prisma } from "@/lib/db";
+import { requireEditor, requireAdmin } from "@/lib/auth";
+import { str, float } from "@/actions/helpers";
+import { parseKmzOrKmlPoints } from "@/lib/kml";
+
+function corralData(formData: FormData) {
+  return {
+    number: str(formData.get("number")),
+    ranch: str(formData.get("ranch")),
+    comment: str(formData.get("comment")),
+    latitude: float(formData.get("latitude")),
+    longitude: float(formData.get("longitude")),
+  };
+}
+
+export async function createCorral(formData: FormData) {
+  await requireEditor();
+  const corral = await prisma.corral.create({ data: corralData(formData) });
+  revalidatePath("/corrals");
+  redirect(`/corrals/${corral.id}?notice=Corral creado correctamente`);
+}
+
+export async function updateCorral(id: number, formData: FormData) {
+  await requireEditor();
+  await prisma.corral.update({ where: { id }, data: corralData(formData) });
+  revalidatePath("/corrals");
+  revalidatePath(`/corrals/${id}`);
+  redirect(`/corrals/${id}?notice=Corral actualizado correctamente`);
+}
+
+export async function deleteCorral(formData: FormData) {
+  await requireAdmin();
+  const id = Number(formData.get("id"));
+  await prisma.corral.delete({ where: { id } });
+  revalidatePath("/corrals");
+  redirect("/corrals?notice=Corral eliminado");
+}
+
+// Importa corrales desde un archivo .kmz/.kml de Google Earth.
+// Cada punto (Placemark con Point) se convierte en un corral: su nombre se usa
+// como número y sus coordenadas como latitud/longitud. Si ya existe un corral
+// con ese número (y misma hacienda, si se indica) se actualiza; si no, se crea.
+export async function importCorralsFromKmz(formData: FormData) {
+  await requireEditor();
+
+  const file = formData.get("file");
+  const ranch = str(formData.get("ranch"));
+
+  if (!file || typeof file === "string" || file.size === 0) {
+    redirect("/corrals/import?error=Selecciona un archivo .kmz o .kml válido");
+  }
+
+  const bytes = new Uint8Array(await (file as File).arrayBuffer());
+
+  let points;
+  try {
+    points = await parseKmzOrKmlPoints(bytes);
+  } catch {
+    redirect(
+      "/corrals/import?error=No se pudo leer el archivo. ¿Es un .kmz/.kml válido?",
+    );
+  }
+
+  if (!points || points.length === 0) {
+    redirect(
+      "/corrals/import?error=No se encontraron puntos (corrales) en el archivo",
+    );
+  }
+
+  let created = 0;
+  let updated = 0;
+
+  for (const pt of points) {
+    const number = pt.name;
+    const data = {
+      number,
+      ranch,
+      latitude: pt.latitude,
+      longitude: pt.longitude,
+      comment: pt.description,
+    };
+
+    const existing = await prisma.corral.findFirst({
+      where: { number, ...(ranch ? { ranch } : {}) },
+    });
+
+    if (existing) {
+      // No sobrescribimos hacienda si ya la tenía y no se indicó.
+      await prisma.corral.update({
+        where: { id: existing.id },
+        data: {
+          number,
+          latitude: pt.latitude,
+          longitude: pt.longitude,
+          ranch: ranch ?? existing.ranch,
+          comment: pt.description ?? existing.comment,
+        },
+      });
+      updated++;
+    } else {
+      await prisma.corral.create({ data });
+      created++;
+    }
+  }
+
+  revalidatePath("/corrals");
+  redirect(
+    `/corrals?notice=${created} corral(es) creado(s) y ${updated} actualizado(s) desde el archivo`,
+  );
+}

--- a/src/actions/lots.ts
+++ b/src/actions/lots.ts
@@ -18,6 +18,7 @@ function lotData(formData: FormData) {
     name: str(formData.get("name")),
     description: str(formData.get("description")),
     plotId: int(formData.get("plot_id")),
+    corralId: int(formData.get("corral_id")),
     status,
     saleDate: sold ? date(formData.get("sale_date")) : null,
     buyer: sold ? str(formData.get("buyer")) : null,

--- a/src/app/(app)/corrals/[id]/edit/page.tsx
+++ b/src/app/(app)/corrals/[id]/edit/page.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { prisma } from "@/lib/db";
+import { requireAdmin } from "@/lib/auth";
+import { updateCorral } from "@/actions/corrals";
+import { CorralForm } from "@/components/entity-forms/CorralForm";
+import { ArrowLeftIcon } from "@/components/icons";
+
+export const dynamic = "force-dynamic";
+
+export default async function EditCorralPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  await requireAdmin();
+  const { id } = await params;
+  const corralId = Number(id);
+  if (Number.isNaN(corralId)) notFound();
+  const [corral, haciendas] = await Promise.all([
+    prisma.corral.findUnique({ where: { id: corralId } }),
+    prisma.hacienda.findMany({
+      orderBy: { name: "asc" },
+      select: { id: true, name: true },
+    }),
+  ]);
+  if (!corral) notFound();
+
+  return (
+    <div>
+      <Link
+        href={`/corrals/${corral.id}`}
+        className="mb-4 inline-flex items-center gap-1 text-sm font-medium text-slate-500 hover:text-slate-800"
+      >
+        <ArrowLeftIcon width={16} height={16} /> Corral {corral.number}
+      </Link>
+      <h1 className="mb-5 text-2xl font-bold tracking-tight text-slate-900">
+        Editar corral
+      </h1>
+      <CorralForm
+        action={updateCorral.bind(null, corral.id)}
+        corral={corral}
+        haciendas={haciendas}
+        submitLabel="Guardar cambios"
+      />
+    </div>
+  );
+}

--- a/src/app/(app)/corrals/[id]/page.tsx
+++ b/src/app/(app)/corrals/[id]/page.tsx
@@ -1,0 +1,155 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { prisma } from "@/lib/db";
+import { getCurrentUser, isAdmin, isEditor } from "@/lib/auth";
+import { deleteCorral } from "@/actions/corrals";
+import { Card, DescList, TableWrap, Th, Td, Badge, EmptyState } from "@/components/ui";
+import { DeleteButton } from "@/components/DeleteButton";
+import { ArrowLeftIcon, EditIcon, ChevronRightIcon, LotsIcon } from "@/components/icons";
+import { fmtNumber, lotHeadcount } from "@/lib/utils";
+import { lotStatusLabel, lotStatusBadgeColor } from "@/lib/lotStatus";
+import { CorralMap } from "@/components/CorralMap";
+
+export const dynamic = "force-dynamic";
+
+export default async function CorralShowPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const corralId = Number(id);
+  if (Number.isNaN(corralId)) notFound();
+
+  const [corral, user] = await Promise.all([
+    prisma.corral.findUnique({
+      where: { id: corralId },
+      include: {
+        lots: {
+          orderBy: [{ number: "asc" }],
+          include: {
+            _count: { select: { animals: true } },
+            weighings: {
+              orderBy: [{ date: "desc" }, { id: "desc" }],
+              take: 1,
+              select: { animalCount: true },
+            },
+          },
+        },
+      },
+    }),
+    getCurrentUser(),
+  ]);
+  if (!corral) notFound();
+
+  const canEdit = isEditor(user?.role);
+  const canDelete = isAdmin(user?.role);
+  const hasLocation = corral.latitude != null && corral.longitude != null;
+
+  // Cabezas en el corral: suma del número de cabezas de los lotes ubicados aquí.
+  const animalCount = corral.lots.reduce((sum, lot) => sum + lotHeadcount(lot), 0);
+
+  const details = [
+    { label: "Número", value: corral.number ?? "—" },
+    { label: "Hacienda", value: corral.ranch ?? "—" },
+    {
+      label: "Cabezas",
+      value: <Badge color="green">{fmtNumber(animalCount)}</Badge>,
+    },
+    {
+      label: "Ubicación",
+      value: hasLocation
+        ? `${fmtNumber(corral.latitude, 6)}, ${fmtNumber(corral.longitude, 6)}`
+        : "—",
+    },
+    { label: "Comentario", value: corral.comment ?? "—" },
+  ];
+
+  return (
+    <div>
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <Link
+          href="/corrals"
+          className="inline-flex items-center gap-1 text-sm font-medium text-slate-500 hover:text-slate-800"
+        >
+          <ArrowLeftIcon width={16} height={16} /> Corrales
+        </Link>
+        <div className="flex items-center gap-2">
+          {canEdit && (
+            <Link
+              href={`/corrals/${corral.id}/edit`}
+              className="inline-flex items-center gap-1.5 rounded-xl border border-slate-300 bg-white px-3.5 py-2.5 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50"
+            >
+              <EditIcon width={16} height={16} /> Editar
+            </Link>
+          )}
+          {canDelete && <DeleteButton action={deleteCorral} id={corral.id} />}
+        </div>
+      </div>
+
+      <h1 className="mb-6 text-2xl font-bold tracking-tight text-slate-900">
+        Corral {corral.number}
+      </h1>
+
+      {hasLocation && (
+        <div className="mb-5">
+          <CorralMap lat={corral.latitude!} lng={corral.longitude!} />
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 gap-5 lg:grid-cols-3">
+        <Card className="lg:col-span-1">
+          <DescList items={details} />
+        </Card>
+
+        <div className="lg:col-span-2">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-400">
+            Lotes en este corral
+          </h2>
+
+          {corral.lots.length === 0 ? (
+            <EmptyState
+              icon={<LotsIcon width={24} height={24} />}
+              title="Sin lotes"
+              description="Asigna lotes a este corral desde la ficha de cada lote."
+            />
+          ) : (
+            <TableWrap>
+              <thead>
+                <tr>
+                  <Th>Lote</Th>
+                  <Th>Estado</Th>
+                  <Th className="text-right">Cabezas</Th>
+                  <Th></Th>
+                </tr>
+              </thead>
+              <tbody>
+                {corral.lots.map((lot) => (
+                  <tr key={lot.id} className="hover:bg-slate-50">
+                    <Td className="font-semibold text-slate-900">
+                      {lot.name || lot.number || `#${lot.id}`}
+                    </Td>
+                    <Td>
+                      <Badge color={lotStatusBadgeColor(lot.status)}>
+                        {lotStatusLabel(lot.status)}
+                      </Badge>
+                    </Td>
+                    <Td className="text-right">{fmtNumber(lotHeadcount(lot))}</Td>
+                    <Td>
+                      <Link
+                        href={`/lots/${lot.id}`}
+                        className="inline-flex text-brand-600"
+                      >
+                        <ChevronRightIcon />
+                      </Link>
+                    </Td>
+                  </tr>
+                ))}
+              </tbody>
+            </TableWrap>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/corrals/import/page.tsx
+++ b/src/app/(app)/corrals/import/page.tsx
@@ -1,0 +1,98 @@
+import Link from "next/link";
+import { prisma } from "@/lib/db";
+import { requireEditor } from "@/lib/auth";
+import { importCorralsFromKmz } from "@/actions/corrals";
+import { Card } from "@/components/ui";
+import { Field, SubmitButton, FormError } from "@/components/forms";
+import { RanchSelect } from "@/components/RanchSelect";
+import { ArrowLeftIcon, CorralIcon } from "@/components/icons";
+
+export const dynamic = "force-dynamic";
+
+export default async function ImportCorralsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string }>;
+}) {
+  await requireEditor();
+  const { error } = await searchParams;
+  const haciendas = await prisma.hacienda.findMany({
+    orderBy: { name: "asc" },
+    select: { id: true, name: true },
+  });
+
+  return (
+    <div>
+      <Link
+        href="/corrals"
+        className="mb-4 inline-flex items-center gap-1 text-sm font-medium text-slate-500 hover:text-slate-800"
+      >
+        <ArrowLeftIcon width={16} height={16} /> Corrales
+      </Link>
+      <h1 className="mb-1 text-2xl font-bold tracking-tight text-slate-900">
+        Importar corrales desde Google Earth
+      </h1>
+      <p className="mb-5 text-sm text-slate-500">
+        Sube un archivo <span className="font-semibold">.kmz</span> o{" "}
+        <span className="font-semibold">.kml</span>. Cada punto (marcador) se
+        convierte en un corral.
+      </p>
+
+      <form action={importCorralsFromKmz}>
+        <Card className="space-y-5 p-5 sm:p-6">
+          <FormError message={error} />
+
+          <Field
+            label="Archivo .kmz / .kml"
+            hint="Exporta tus corrales (marcadores) desde Google Earth como KMZ."
+          >
+            <input
+              type="file"
+              name="file"
+              accept=".kmz,.kml,application/vnd.google-earth.kmz,application/vnd.google-earth.kml+xml"
+              required
+              className="block w-full text-sm text-slate-600 file:mr-4 file:rounded-xl file:border-0 file:bg-brand-600 file:px-4 file:py-2.5 file:text-sm file:font-semibold file:text-white hover:file:bg-brand-700"
+            />
+          </Field>
+
+          <Field
+            label="Hacienda"
+            hint="Se asigna a todos los corrales importados."
+          >
+            <RanchSelect haciendas={haciendas} />
+          </Field>
+
+          <div className="rounded-xl bg-brand-50 p-4 text-sm text-brand-900">
+            <p className="mb-1 flex items-center gap-1.5 font-semibold">
+              <CorralIcon width={16} height={16} /> Cómo funciona
+            </p>
+            <ul className="ml-5 list-disc space-y-0.5 text-brand-800">
+              <li>
+                El <strong>nombre</strong> de cada punto se usa como{" "}
+                <strong>número de corral</strong>.
+              </li>
+              <li>
+                Las <strong>coordenadas</strong> del punto se guardan como{" "}
+                <strong>latitud y longitud</strong>.
+              </li>
+              <li>
+                Si ya existe un corral con ese número {`(y misma hacienda)`} se{" "}
+                <strong>actualiza</strong>; si no, se <strong>crea</strong>.
+              </li>
+            </ul>
+          </div>
+
+          <div className="flex items-center gap-3 pt-1">
+            <SubmitButton>Importar corrales</SubmitButton>
+            <Link
+              href="/corrals"
+              className="rounded-xl px-4 py-2.5 text-sm font-semibold text-slate-600 hover:bg-slate-100"
+            >
+              Cancelar
+            </Link>
+          </div>
+        </Card>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(app)/corrals/new/page.tsx
+++ b/src/app/(app)/corrals/new/page.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+import { prisma } from "@/lib/db";
+import { requireEditor } from "@/lib/auth";
+import { createCorral } from "@/actions/corrals";
+import { CorralForm } from "@/components/entity-forms/CorralForm";
+import { ArrowLeftIcon } from "@/components/icons";
+
+export const dynamic = "force-dynamic";
+
+export default async function NewCorralPage() {
+  await requireEditor();
+  const haciendas = await prisma.hacienda.findMany({
+    orderBy: { name: "asc" },
+    select: { id: true, name: true },
+  });
+  return (
+    <div>
+      <Link
+        href="/corrals"
+        className="mb-4 inline-flex items-center gap-1 text-sm font-medium text-slate-500 hover:text-slate-800"
+      >
+        <ArrowLeftIcon width={16} height={16} /> Corrales
+      </Link>
+      <h1 className="mb-5 text-2xl font-bold tracking-tight text-slate-900">
+        Nuevo corral
+      </h1>
+      <CorralForm
+        action={createCorral}
+        haciendas={haciendas}
+        submitLabel="Crear corral"
+      />
+    </div>
+  );
+}

--- a/src/app/(app)/corrals/page.tsx
+++ b/src/app/(app)/corrals/page.tsx
@@ -1,0 +1,143 @@
+import Link from "next/link";
+import { prisma } from "@/lib/db";
+import { EmptyState, TableWrap, Th, Td, Card, Badge } from "@/components/ui";
+import { CorralIcon, ChevronRightIcon, PlusIcon } from "@/components/icons";
+import { fmtNumber, lotHeadcount } from "@/lib/utils";
+import { getActiveHacienda } from "@/lib/activeHacienda";
+import { getCurrentUser, isEditor } from "@/lib/auth";
+
+export const dynamic = "force-dynamic";
+
+export default async function CorralsPage() {
+  const activeHacienda = await getActiveHacienda();
+  const [corrals, user] = await Promise.all([
+    prisma.corral.findMany({
+      where: activeHacienda ? { ranch: activeHacienda } : undefined,
+      orderBy: [{ ranch: "asc" }, { number: "asc" }],
+      include: {
+        lots: {
+          select: {
+            _count: { select: { animals: true } },
+            weighings: {
+              orderBy: [{ date: "desc" }, { id: "desc" }],
+              take: 1,
+              select: { animalCount: true },
+            },
+          },
+        },
+      },
+    }),
+    getCurrentUser(),
+  ]);
+  const canEdit = isEditor(user?.role);
+
+  // Cabezas por corral: suma del número de cabezas de los lotes ubicados ahí.
+  const headcount = (corral: (typeof corrals)[number]) =>
+    corral.lots.reduce((sum, lot) => sum + lotHeadcount(lot), 0);
+
+  return (
+    <div>
+      <div className="mb-5 flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight text-slate-900">
+            Corrales
+          </h1>
+          <p className="mt-0.5 text-sm text-slate-500">
+            {fmtNumber(corrals.length)} corrales registrados
+            {activeHacienda ? ` · ${activeHacienda}` : ""}
+          </p>
+        </div>
+        {canEdit && (
+          <div className="flex items-center gap-2">
+            <Link
+              href="/corrals/import"
+              className="inline-flex items-center gap-1.5 rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 active:scale-[0.98]"
+            >
+              <CorralIcon width={18} height={18} />
+              Importar KMZ
+            </Link>
+            <Link
+              href="/corrals/new"
+              className="inline-flex items-center gap-1.5 rounded-xl bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-700 active:scale-[0.98]"
+            >
+              <PlusIcon width={18} height={18} />
+              Nuevo corral
+            </Link>
+          </div>
+        )}
+      </div>
+
+      {corrals.length === 0 ? (
+        <EmptyState
+          icon={<CorralIcon width={26} height={26} />}
+          title="Sin corrales"
+          description="Registra tus corrales con su ubicación para asignarles lotes de ganado."
+          action={canEdit ? { href: "/corrals/new", label: "Nuevo corral" } : undefined}
+        />
+      ) : (
+        <>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:hidden">
+            {corrals.map((corral) => (
+              <Link key={corral.id} href={`/corrals/${corral.id}`}>
+                <Card className="p-4">
+                  <div className="flex items-center justify-between">
+                    <p className="font-bold text-slate-900">
+                      Corral {corral.number}
+                    </p>
+                    <Badge color="green">{fmtNumber(headcount(corral))} cab.</Badge>
+                  </div>
+                  <p className="text-xs text-slate-500">
+                    {corral.ranch ?? "—"}
+                    {corral.latitude != null && corral.longitude != null
+                      ? ` · ${fmtNumber(corral.latitude, 4)}, ${fmtNumber(corral.longitude, 4)}`
+                      : ""}
+                  </p>
+                </Card>
+              </Link>
+            ))}
+          </div>
+
+          <div className="hidden lg:block">
+            <TableWrap>
+              <thead>
+                <tr>
+                  <Th>Corral</Th>
+                  <Th>Hacienda</Th>
+                  <Th>Ubicación</Th>
+                  <Th className="text-right">Cabezas</Th>
+                  <Th></Th>
+                </tr>
+              </thead>
+              <tbody>
+                {corrals.map((corral) => (
+                  <tr key={corral.id} className="hover:bg-slate-50">
+                    <Td className="font-semibold text-slate-900">
+                      {corral.number ?? corral.id}
+                    </Td>
+                    <Td>{corral.ranch ?? "—"}</Td>
+                    <Td>
+                      {corral.latitude != null && corral.longitude != null
+                        ? `${fmtNumber(corral.latitude, 5)}, ${fmtNumber(corral.longitude, 5)}`
+                        : "—"}
+                    </Td>
+                    <Td className="text-right">
+                      <Badge color="green">{fmtNumber(headcount(corral))}</Badge>
+                    </Td>
+                    <Td>
+                      <Link
+                        href={`/corrals/${corral.id}`}
+                        className="inline-flex text-brand-600"
+                      >
+                        <ChevronRightIcon />
+                      </Link>
+                    </Td>
+                  </tr>
+                ))}
+              </tbody>
+            </TableWrap>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/lots/[id]/edit/page.tsx
+++ b/src/app/(app)/lots/[id]/edit/page.tsx
@@ -17,7 +17,7 @@ export default async function EditLotPage({
   const { id } = await params;
   const lotId = Number(id);
   if (Number.isNaN(lotId)) notFound();
-  const [lot, haciendas, plots] = await Promise.all([
+  const [lot, haciendas, plots, corrals] = await Promise.all([
     prisma.lot.findUnique({ where: { id: lotId } }),
     prisma.hacienda.findMany({
       orderBy: { name: "asc" },
@@ -26,6 +26,10 @@ export default async function EditLotPage({
     prisma.plot.findMany({
       orderBy: [{ ranch: "asc" }, { number: "asc" }],
       select: { id: true, number: true, ranch: true, plotType: true },
+    }),
+    prisma.corral.findMany({
+      orderBy: [{ ranch: "asc" }, { number: "asc" }],
+      select: { id: true, number: true, ranch: true },
     }),
   ]);
   if (!lot) notFound();
@@ -46,6 +50,7 @@ export default async function EditLotPage({
         lot={lot}
         haciendas={haciendas}
         plots={plots}
+        corrals={corrals}
         submitLabel="Guardar cambios"
       />
     </div>

--- a/src/app/(app)/lots/[id]/page.tsx
+++ b/src/app/(app)/lots/[id]/page.tsx
@@ -69,6 +69,7 @@ export default async function LotShowPage({
       where: { id: lotId },
       include: {
         plot: true,
+        corral: true,
         animals: { orderBy: { animalNumber: "asc" } },
         weighings: { orderBy: [{ date: "desc" }, { id: "desc" }] },
       },
@@ -165,6 +166,21 @@ export default async function LotShowPage({
                     {lot.plot.number
                       ? `Potrero ${lot.plot.number}`
                       : `#${lot.plot.id}`}
+                  </Link>
+                ) : (
+                  "—"
+                ),
+              },
+              {
+                label: "Corral",
+                value: lot.corral ? (
+                  <Link
+                    href={`/corrals/${lot.corral.id}`}
+                    className="text-brand-600"
+                  >
+                    {lot.corral.number
+                      ? `Corral ${lot.corral.number}`
+                      : `#${lot.corral.id}`}
                   </Link>
                 ) : (
                   "—"

--- a/src/app/(app)/lots/new/page.tsx
+++ b/src/app/(app)/lots/new/page.tsx
@@ -9,7 +9,7 @@ export const dynamic = "force-dynamic";
 
 export default async function NewLotPage() {
   await requireEditor();
-  const [haciendas, plots] = await Promise.all([
+  const [haciendas, plots, corrals] = await Promise.all([
     prisma.hacienda.findMany({
       orderBy: { name: "asc" },
       select: { id: true, name: true },
@@ -17,6 +17,10 @@ export default async function NewLotPage() {
     prisma.plot.findMany({
       orderBy: [{ ranch: "asc" }, { number: "asc" }],
       select: { id: true, number: true, ranch: true, plotType: true },
+    }),
+    prisma.corral.findMany({
+      orderBy: [{ ranch: "asc" }, { number: "asc" }],
+      select: { id: true, number: true, ranch: true },
     }),
   ]);
   return (
@@ -34,6 +38,7 @@ export default async function NewLotPage() {
         action={createLot}
         haciendas={haciendas}
         plots={plots}
+        corrals={corrals}
         submitLabel="Crear lote"
       />
     </div>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -12,6 +12,7 @@ import {
   CowIcon,
   LotsIcon,
   PlotIcon,
+  CorralIcon,
   MoneyIcon,
   ScaleIcon,
   MenuIcon,
@@ -36,6 +37,7 @@ const NAV: NavItem[] = [
   { href: "/animals", label: "Animales", Icon: CowIcon },
   { href: "/lots", label: "Lotes", Icon: LotsIcon },
   { href: "/plots", label: "Potreros", Icon: PlotIcon },
+  { href: "/corrals", label: "Corrales", Icon: CorralIcon },
   { href: "/sales", label: "Ventas", Icon: MoneyIcon },
   { href: "/weights", label: "Pesos", Icon: ScaleIcon },
 ];

--- a/src/components/CorralMap.tsx
+++ b/src/components/CorralMap.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import "leaflet/dist/leaflet.css";
+
+// Mapa satelital con la ubicación puntual del corral marcada.
+// `lat`/`lng` son las coordenadas del corral. Leaflet se carga de forma diferida
+// (solo en el cliente) para evitar acceder a `window` en SSR.
+export function CorralMap({ lat, lng }: { lat: number; lng: number }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) return;
+    let map: import("leaflet").Map | undefined;
+    let cancelled = false;
+
+    (async () => {
+      const L = (await import("leaflet")).default;
+      const el = containerRef.current;
+      if (!el || cancelled) return;
+      // Evita reinicializar sobre un contenedor ya usado (StrictMode).
+      if ((el as unknown as { _leaflet_id?: number })._leaflet_id) return;
+
+      map = L.map(el, {
+        scrollWheelZoom: false,
+        attributionControl: true,
+      }).setView([lat, lng], 16);
+
+      // Imágenes satelitales (Esri World Imagery) — sin API key.
+      L.tileLayer(
+        "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+        {
+          maxZoom: 19,
+          attribution: "Imágenes &copy; Esri, Maxar, Earthstar Geographics",
+        },
+      ).addTo(map);
+
+      // Etiquetas de carreteras/lugares encima del satélite.
+      L.tileLayer(
+        "https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}",
+        { maxZoom: 19, opacity: 0.9 },
+      ).addTo(map);
+
+      // Marcador circular (evita depender de los íconos PNG de Leaflet, que no
+      // se resuelven bien con el bundler).
+      L.circleMarker([lat, lng], {
+        radius: 9,
+        color: "#f59e0b",
+        weight: 3,
+        fillColor: "#f59e0b",
+        fillOpacity: 0.6,
+      }).addTo(map);
+    })();
+
+    return () => {
+      cancelled = true;
+      if (map) map.remove();
+    };
+  }, [lat, lng]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-80 w-full overflow-hidden rounded-2xl border border-slate-200 bg-slate-100 sm:h-96"
+    />
+  );
+}

--- a/src/components/entity-forms/CorralForm.tsx
+++ b/src/components/entity-forms/CorralForm.tsx
@@ -1,0 +1,60 @@
+import Link from "next/link";
+import type { Corral } from "@prisma/client";
+import { Card } from "@/components/ui";
+import { Field, Input, Textarea, SubmitButton } from "@/components/forms";
+import { RanchSelect } from "@/components/RanchSelect";
+
+export function CorralForm({
+  action,
+  corral,
+  haciendas,
+  submitLabel,
+}: {
+  action: (formData: FormData) => void | Promise<void>;
+  corral?: Corral | null;
+  haciendas: { id: number; name: string }[];
+  submitLabel: string;
+}) {
+  return (
+    <form action={action}>
+      <Card className="space-y-5 p-5 sm:p-6">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <Field label="Número de corral">
+            <Input name="number" defaultValue={corral?.number ?? ""} />
+          </Field>
+          <Field label="Hacienda">
+            <RanchSelect haciendas={haciendas} defaultValue={corral?.ranch} />
+          </Field>
+          <Field label="Latitud" hint="Ej. 14.0723">
+            <Input
+              type="number"
+              step="any"
+              name="latitude"
+              defaultValue={corral?.latitude ?? ""}
+            />
+          </Field>
+          <Field label="Longitud" hint="Ej. -87.1921">
+            <Input
+              type="number"
+              step="any"
+              name="longitude"
+              defaultValue={corral?.longitude ?? ""}
+            />
+          </Field>
+        </div>
+        <Field label="Comentario">
+          <Textarea name="comment" defaultValue={corral?.comment ?? ""} />
+        </Field>
+        <div className="flex items-center gap-3 pt-1">
+          <SubmitButton>{submitLabel}</SubmitButton>
+          <Link
+            href={corral ? `/corrals/${corral.id}` : "/corrals"}
+            className="rounded-xl px-4 py-2.5 text-sm font-semibold text-slate-600 hover:bg-slate-100"
+          >
+            Cancelar
+          </Link>
+        </div>
+      </Card>
+    </form>
+  );
+}

--- a/src/components/entity-forms/LotForm.tsx
+++ b/src/components/entity-forms/LotForm.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import type { Lot, Plot } from "@prisma/client";
+import type { Lot, Plot, Corral } from "@prisma/client";
 import { Card } from "@/components/ui";
 import { Field, Input, Select, Textarea, SubmitButton } from "@/components/forms";
 import { RanchSelect } from "@/components/RanchSelect";
@@ -10,12 +10,14 @@ export function LotForm({
   lot,
   haciendas,
   plots,
+  corrals,
   submitLabel,
 }: {
   action: (formData: FormData) => void | Promise<void>;
   lot?: Lot | null;
   haciendas: { id: number; name: string }[];
   plots: Pick<Plot, "id" | "number" | "ranch" | "plotType">[];
+  corrals: Pick<Corral, "id" | "number" | "ranch">[];
   submitLabel: string;
 }) {
   return (
@@ -38,6 +40,16 @@ export function LotForm({
                 <option key={p.id} value={p.id}>
                   {[p.ranch, p.plotType, p.number].filter(Boolean).join(" · ") ||
                     `#${p.id}`}
+                </option>
+              ))}
+            </Select>
+          </Field>
+          <Field label="Corral" hint="Ubicación del lote">
+            <Select name="corral_id" defaultValue={lot?.corralId ?? ""}>
+              <option value="">— Sin corral —</option>
+              {corrals.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {[c.ranch, c.number].filter(Boolean).join(" · ") || `#${c.id}`}
                 </option>
               ))}
             </Select>

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -245,3 +245,12 @@ export function SettingsIcon(p: IconProps) {
     </svg>
   );
 }
+
+export function CorralIcon(p: IconProps) {
+  return (
+    <svg {...base} {...p}>
+      <path d="M21 10c0 6-9 12-9 12s-9-6-9-12a9 9 0 0 1 18 0z" />
+      <circle cx="12" cy="10" r="3" />
+    </svg>
+  );
+}

--- a/src/lib/kml.ts
+++ b/src/lib/kml.ts
@@ -9,6 +9,14 @@ export type ParsedPolygon = {
   areaHectares: number | null;
 };
 
+export type ParsedPoint = {
+  name: string;
+  description: string | null;
+  // Coordenadas en formato GeoJSON (lng, lat).
+  longitude: number;
+  latitude: number;
+};
+
 const EARTH_RADIUS_M = 6378137;
 
 // Área geodésica de un polígono (fórmula de exceso esférico) en hectáreas.
@@ -70,6 +78,32 @@ function extractRing(placemark: Record<string, unknown>): [number, number][] {
     if (parsed.length >= 3) return parsed;
   }
   return [];
+}
+
+// Extrae la primera coordenada de un Point dentro de un Placemark.
+function extractPoint(
+  placemark: Record<string, unknown>,
+): [number, number] | null {
+  const points: unknown[] = [];
+  const collectPoints = (node: unknown) => {
+    if (!node || typeof node !== "object") return;
+    const obj = node as Record<string, unknown>;
+    if (obj.Point) {
+      const p = obj.Point;
+      if (Array.isArray(p)) points.push(...p);
+      else points.push(p);
+    }
+    if (obj.MultiGeometry) collectPoints(obj.MultiGeometry);
+  };
+  collectPoints(placemark);
+
+  for (const point of points) {
+    if (!point || typeof point !== "object") continue;
+    const coords = (point as Record<string, unknown>).coordinates;
+    const parsed = parseCoordinates(coords);
+    if (parsed.length >= 1) return parsed[0];
+  }
+  return null;
 }
 
 // Recorre el árbol KML recolectando todos los nodos Placemark.
@@ -147,6 +181,36 @@ export async function parseKmzOrKml(
       description: stripHtml(textOf(pm.description)),
       ring,
       areaHectares: ringAreaHectares(ring),
+    });
+  }
+  return result;
+}
+
+// Igual que parseKmzOrKml pero extrae puntos (Placemark > Point) en vez de
+// polígonos. Se usa para importar corrales, que son ubicaciones puntuales.
+export async function parseKmzOrKmlPoints(
+  bytes: Uint8Array,
+): Promise<ParsedPoint[]> {
+  const xml = await extractKmlText(bytes);
+  const parser = new XMLParser({
+    ignoreAttributes: true,
+    parseTagValue: false,
+    trimValues: true,
+  });
+  const doc = parser.parse(xml);
+
+  const placemarks: Record<string, unknown>[] = [];
+  collectPlacemarks(doc, placemarks);
+
+  const result: ParsedPoint[] = [];
+  for (const pm of placemarks) {
+    const point = extractPoint(pm);
+    if (!point) continue; // sin punto usable
+    result.push({
+      name: textOf(pm.name) ?? "Sin nombre",
+      description: stripHtml(textOf(pm.description)),
+      longitude: point[0],
+      latitude: point[1],
     });
   }
   return result;


### PR DESCRIPTION
## Resumen

Agrega una base de datos de **corrales** con funcionalidad análoga a la de potreros, pero usando una **ubicación puntual** (latitud/longitud) en lugar de un polígono. Los lotes de ganado pueden asignarse a un corral igual que a un potrero.

## Cambios

**Modelo y base de datos**
- Modelo `Corral` (tabla `corrals`): `number`, `ranch`, `comment`, `latitude`, `longitude`.
- Columna `lots.corral_id` con relación → un lote puede tener potrero, corral, ambos o ninguno.
- Migración incremental idempotente `prisma/neon-corrals.sql` y actualización de `prisma/neon-setup.sql`.

**CRUD `/corrals`** (espejo de potreros)
- Lista con tarjetas (móvil) y tabla (escritorio): ubicación y cabezas por corral.
- Ficha con mapa satelital (Esri) y marcador en el punto, datos, total de cabezas y lotes asignados.
- Crear / Editar con `CorralForm`; permisos respetados (editor crea/edita, admin elimina).

**Importación KMZ/KML**
- Página `/corrals/import` y acción `importCorralsFromKmz`.
- `parseKmzOrKmlPoints` en `src/lib/kml.ts`: extrae puntos (`Placemark > Point`). Nombre → número, coordenadas → lat/lng. Crea o actualiza según número (y hacienda).

**Integración con lotes**
- Selector "Corral" en `LotForm`, guardado en `createLot`/`updateLot`.
- Enlace al corral en la ficha del lote.
- Entrada "Corrales" en la navegación con nuevo `CorralIcon`.

## Verificación
- `tsc --noEmit` ✅
- `next build` ✅ (rutas `/corrals`, `/corrals/[id]`, `/corrals/[id]/edit`, `/corrals/import`, `/corrals/new` generadas)

## Migración requerida
Aplicar una vez `prisma/neon-corrals.sql` en el SQL Editor de Neon, o `npm run db:push`, para crear la tabla `corrals` y la columna `lots.corral_id`.

https://claude.ai/code/session_013aQk2HmsZdfNceeM8pnSZ1

---
_Generated by [Claude Code](https://claude.ai/code/session_013aQk2HmsZdfNceeM8pnSZ1)_