### PR TITLE
Mapa de corrales en el tablero y columna de corral en lotes

### DIFF
--- a/src/app/(app)/lots/page.tsx
+++ b/src/app/(app)/lots/page.tsx
@@ -16,6 +16,7 @@ export default async function LotsPage() {
       include: {
         _count: { select: { animals: true } },
         plot: { select: { id: true, number: true } },
+        corral: { select: { id: true, number: true } },
         // Último pesado del lote: define el peso promedio y el número de cabezas.
         weighings: { orderBy: [{ date: "desc" }, { id: "desc" }], take: 1 },
       },
@@ -61,9 +62,12 @@ export default async function LotsPage() {
                       {latest?.animalCount ?? lot._count.animals} cabezas
                     </p>
                     <p className="text-xs text-slate-500">
-                      {lot.plot?.number
-                        ? `Potrero ${lot.plot.number}`
-                        : "Sin potrero"}
+                      {[
+                        lot.plot?.number ? `Potrero ${lot.plot.number}` : null,
+                        lot.corral?.number ? `Corral ${lot.corral.number}` : null,
+                      ]
+                        .filter(Boolean)
+                        .join(" · ") || "Sin ubicación"}
                     </p>
                     <div className="mt-3 grid grid-cols-2 gap-2 text-center text-sm">
                       <div className="rounded-lg bg-slate-50 py-1.5">
@@ -91,6 +95,7 @@ export default async function LotsPage() {
                   <Th>Lote</Th>
                   <Th>Estado</Th>
                   <Th>Potrero</Th>
+                  <Th>Corral</Th>
                   <Th className="text-right">Cabezas</Th>
                   <Th className="text-right">Peso promedio</Th>
                   <Th className="text-right">Último pesado</Th>
@@ -112,6 +117,9 @@ export default async function LotsPage() {
                       </Td>
                       <Td>
                         {lot.plot?.number ? `Potrero ${lot.plot.number}` : "—"}
+                      </Td>
+                      <Td>
+                        {lot.corral?.number ? `Corral ${lot.corral.number}` : "—"}
                       </Td>
                       <Td className="text-right">
                         {latest?.animalCount ?? lot._count.animals}

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -10,6 +10,10 @@ import { normalizeLotStatus } from "@/lib/lotStatus";
 import { parseGeoJsonRing } from "@/lib/kml";
 import { PlotsOverviewMap, type PlotMarker } from "@/components/PlotsOverviewMap";
 import {
+  CorralsOverviewMap,
+  type CorralMarker,
+} from "@/components/CorralsOverviewMap";
+import {
   CowIcon,
   ScaleIcon,
   CalendarIcon,
@@ -23,7 +27,7 @@ export const dynamic = "force-dynamic";
 
 export default async function DashboardPage() {
   const weightMode = await getWeightMode();
-  const [stats, user, unit, plots] = await Promise.all([
+  const [stats, user, unit, plots, corrals] = await Promise.all([
     getDashboardStats(undefined, weightMode),
     getCurrentUser(),
     getWeightUnit(),
@@ -32,6 +36,25 @@ export default async function DashboardPage() {
         id: true,
         number: true,
         boundaries: true,
+        lots: {
+          select: {
+            status: true,
+            _count: { select: { animals: true } },
+            weighings: {
+              orderBy: [{ date: "desc" }, { id: "desc" }],
+              take: 1,
+              select: { animalCount: true },
+            },
+          },
+        },
+      },
+    }),
+    prisma.corral.findMany({
+      select: {
+        id: true,
+        number: true,
+        latitude: true,
+        longitude: true,
         lots: {
           select: {
             status: true,
@@ -68,6 +91,24 @@ export default async function DashboardPage() {
       };
     })
     .filter((m): m is PlotMarker => m !== null);
+
+  // Marcadores del mapa de corrales: corrales con ubicación + número de cabezas.
+  // Igual que en potreros, solo los lotes en crecimiento aportan cabezas.
+  const corralMarkers: CorralMarker[] = corrals
+    .map((c) => {
+      if (c.latitude == null || c.longitude == null) return null;
+      const animalCount = c.lots
+        .filter((lot) => normalizeLotStatus(lot.status) === "growing")
+        .reduce((sum, lot) => sum + lotHeadcount(lot), 0);
+      return {
+        id: c.id,
+        label: `Corral ${c.number ?? c.id}`,
+        lat: c.latitude,
+        lng: c.longitude,
+        animalCount,
+      };
+    })
+    .filter((m): m is CorralMarker => m !== null);
 
   return (
     <div>
@@ -154,6 +195,24 @@ export default async function DashboardPage() {
             href="/sales"
           />
         </div>
+      </section>
+
+      <section className="mt-8">
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-400">
+          Mapa de corrales
+        </h2>
+        {corralMarkers.length === 0 ? (
+          <Card className="p-5">
+            <p className="text-sm text-slate-500">
+              Aún no hay corrales con ubicación para mostrar en el mapa. Crea
+              corrales o impórtalos desde un archivo KMZ en{" "}
+              <span className="font-semibold text-slate-700">Corrales</span> para
+              verlos aquí con el número de cabezas en cada uno.
+            </p>
+          </Card>
+        ) : (
+          <CorralsOverviewMap corrals={corralMarkers} />
+        )}
       </section>
 
       <section className="mt-8">

--- a/src/components/CorralsOverviewMap.tsx
+++ b/src/components/CorralsOverviewMap.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import "leaflet/dist/leaflet.css";
+
+export type CorralMarker = {
+  id: number;
+  label: string;
+  // Ubicación puntual del corral.
+  lat: number;
+  lng: number;
+  animalCount: number;
+};
+
+// Mapa satelital con TODOS los corrales marcados en su ubicación puntual y, en
+// cada uno, el número de cabezas que hay en ese corral. Leaflet se carga de
+// forma diferida (solo en el cliente) para evitar acceder a `window` en SSR.
+export function CorralsOverviewMap({ corrals }: { corrals: CorralMarker[] }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const usable = corrals.filter(
+      (c) => Number.isFinite(c.lat) && Number.isFinite(c.lng),
+    );
+    if (usable.length === 0) return;
+    let map: import("leaflet").Map | undefined;
+    let cancelled = false;
+
+    (async () => {
+      const L = (await import("leaflet")).default;
+      const el = containerRef.current;
+      if (!el || cancelled) return;
+      // Evita reinicializar sobre un contenedor ya usado (StrictMode).
+      if ((el as unknown as { _leaflet_id?: number })._leaflet_id) return;
+
+      map = L.map(el, { scrollWheelZoom: false, attributionControl: true });
+
+      // Imágenes satelitales (Esri World Imagery) — sin API key.
+      L.tileLayer(
+        "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+        {
+          maxZoom: 19,
+          attribution: "Imágenes &copy; Esri, Maxar, Earthstar Geographics",
+        },
+      ).addTo(map);
+
+      // Etiquetas de carreteras/lugares encima del satélite.
+      L.tileLayer(
+        "https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}",
+        { maxZoom: 19, opacity: 0.9 },
+      ).addTo(map);
+
+      const bounds = L.latLngBounds([]);
+
+      for (const c of usable) {
+        bounds.extend([c.lat, c.lng]);
+
+        // Si el corral tiene cabezas, se muestra un círculo con el número; si
+        // no, solo un punto que indica su ubicación.
+        if (c.animalCount > 0) {
+          const icon = L.divIcon({
+            className: "corral-count-marker",
+            html: `<div style="display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:9999px;background:#d97706;color:#fff;font-weight:700;font-size:13px;border:2px solid #fff;box-shadow:0 1px 4px rgba(0,0,0,0.4);">${c.animalCount}</div>`,
+            iconSize: [36, 36],
+            iconAnchor: [18, 18],
+          });
+          L.marker([c.lat, c.lng], { icon })
+            .addTo(map!)
+            .bindPopup(`<b>${c.label}</b><br/>${c.animalCount} cabezas`);
+        } else {
+          L.circleMarker([c.lat, c.lng], {
+            radius: 8,
+            color: "#f59e0b",
+            weight: 3,
+            fillColor: "#f59e0b",
+            fillOpacity: 0.6,
+          })
+            .addTo(map!)
+            .bindPopup(`<b>${c.label}</b><br/>Sin cabezas`);
+        }
+      }
+
+      if (bounds.isValid())
+        map.fitBounds(bounds, { padding: [30, 30], maxZoom: 16 });
+    })();
+
+    return () => {
+      cancelled = true;
+      if (map) map.remove();
+    };
+  }, [corrals]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-[30rem] w-full overflow-hidden rounded-2xl border border-slate-200 bg-slate-100 sm:h-[36rem]"
+    />
+  );
+}


### PR DESCRIPTION
## Resumen

Agrega el **mapa de corrales** al tablero y la columna de **corral** en la lista de lotes.

## Cambios

**Tablero (`/`)**
- Nuevo **"Mapa de corrales"** (`CorralsOverviewMap`): muestra cada corral en su ubicación puntual con un círculo que indica el número de cabezas (suma de lotes en crecimiento), siguiendo el mismo patrón del mapa de potreros.
- Se coloca **arriba** del "Mapa de potreros".
- Estado vacío cuando no hay corrales con ubicación.

**Lista de lotes (`/lots`)**
- Nueva columna **"Corral"** en la tabla de escritorio (después de "Potrero").
- El corral asignado también aparece en las tarjetas móvil.

## Verificación
- `tsc --noEmit` ✅
- `next build` ✅

https://claude.ai/code/session_013aQk2HmsZdfNceeM8pnSZ1

---
_Generated by [Claude Code](https://claude.ai/code/session_013aQk2HmsZdfNceeM8pnSZ1)_